### PR TITLE
Add a setting to change the exported symbol names according to the backend naming convention

### DIFF
--- a/backends/csharp/Cargo.toml
+++ b/backends/csharp/Cargo.toml
@@ -15,6 +15,7 @@ unity = []
 
 [dependencies]
 interoptopus = { path = "../../core", version = "0.13.0" }
+heck = "0.4.0"
 
 [dev-dependencies]
 interoptopus = { path = "../../core" }

--- a/backends/csharp/src/config.rs
+++ b/backends/csharp/src/config.rs
@@ -66,6 +66,9 @@ pub struct Config {
     pub write_types: WriteTypes,
     /// If enabled bindings will use C# `unsafe` for increased performance; but will need to be enabled in C# project settings to work.
     pub use_unsafe: Unsafe,
+    // Change the symbolic names of functions and fields to be exported according to the backend naming conventions
+    // Currently, only the C# backend is supported.
+    pub rename_symbols: bool,
     /// Also generate markers for easier debugging
     pub debug: bool,
 }
@@ -84,6 +87,7 @@ impl Default for Config {
             unroll_struct_arrays: false,
             write_types: WriteTypes::NamespaceAndInteroptopusGlobal,
             use_unsafe: Unsafe::None,
+            rename_symbols: false,
             debug: false,
         }
     }

--- a/backends/csharp/src/converter.rs
+++ b/backends/csharp/src/converter.rs
@@ -1,3 +1,4 @@
+use heck::ToUpperCamelCase;
 use interoptopus::lang::c::{
     CType, CompositeType, ConstantValue, EnumType, Field, FnPointerType, Function, FunctionSignature, OpaqueType, Parameter, PrimitiveType, PrimitiveValue,
 };
@@ -199,8 +200,12 @@ pub trait CSharpTypeConverter {
         self.to_typespecifier_in_rval(function.signature().rval())
     }
 
-    fn function_name_to_csharp_name(&self, function: &Function) -> String {
-        function.name().to_string()
+    fn function_name_to_csharp_name(&self, function: &Function, rename_symbols: bool) -> String {
+        if rename_symbols {
+            function.name().to_upper_camel_case()
+        } else {
+            function.name().to_string()
+        }
     }
 }
 

--- a/backends/csharp/src/overloads/dotnet.rs
+++ b/backends/csharp/src/overloads/dotnet.rs
@@ -117,7 +117,7 @@ impl OverloadWriter for DotNet {
         let mut to_pin_name = Vec::new();
         let mut to_pin_slice_type = Vec::new();
         let mut to_invoke = Vec::new();
-        let raw_name = h.converter.function_name_to_csharp_name(function);
+        let raw_name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
         let this_name = if has_error_enum && !has_overload {
             format!("{}_checked", raw_name)
         } else {

--- a/backends/csharp/src/overloads/unity.rs
+++ b/backends/csharp/src/overloads/unity.rs
@@ -108,7 +108,7 @@ impl Unity {
 
     fn write_function_delegate_overload_helper(&self, w: &mut IndentWriter, h: &Helper, function: &Function) -> Result<(), Error> {
         let rval = h.converter.function_rval_to_csharp_typename(function);
-        let name = h.converter.function_name_to_csharp_name(function);
+        let name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
 
         let mut params = Vec::new();
         for (_, p) in function.signature().params().iter().enumerate() {
@@ -192,7 +192,7 @@ impl OverloadWriter for Unity {
         let mut to_pin_name = Vec::new();
         let mut to_pin_slice_type = Vec::new();
         let mut to_invoke = Vec::new();
-        let raw_name = h.converter.function_name_to_csharp_name(function);
+        let raw_name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
         let this_name = if has_error_enum && !has_overload {
             format!("{}_checked", raw_name)
         } else {


### PR DESCRIPTION
Thanks for the useful crate.

I'm not good at English, so I'm not sure myself if the code comments included in this PR are appropriate.