### PR TITLE
Use correct length for C# unsafe copy

### DIFF
--- a/backends/csharp/benches/Interop.common.cs
+++ b/backends/csharp/benches/Interop.common.cs
@@ -97,7 +97,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Bool));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Bool)));
                         #else
@@ -194,7 +194,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -291,7 +291,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else
@@ -407,7 +407,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -523,7 +523,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else

--- a/backends/csharp/benches/Interop.cs
+++ b/backends/csharp/benches/Interop.cs
@@ -1226,7 +1226,7 @@ namespace My.Company
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Vec3f32));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Vec3f32)));
                         #else

--- a/backends/csharp/src/overloads/dotnet.rs
+++ b/backends/csharp/src/overloads/dotnet.rs
@@ -288,9 +288,9 @@ impl OverloadWriter for DotNet {
         Ok(())
     }
 
-    fn write_pattern_slice_unsafe_copied_fragment(&self, w: &mut IndentWriter, _h: Helper, _type_string: &str) -> Result<(), Error> {
+    fn write_pattern_slice_unsafe_copied_fragment(&self, w: &mut IndentWriter, _h: Helper, type_string: &str) -> Result<(), Error> {
         indented!(w, [_ _ _ _ _], r#"#elif NETCOREAPP"#)?;
-        indented!(w, [_ _ _ _ _], r#"Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);"#)?;
+        indented!(w, [_ _ _ _ _], r#"Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof({}));"#, type_string)?;
         Ok(())
     }
 }

--- a/backends/csharp/tests/output_unity/Assets/Interop.common.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.common.cs
@@ -97,7 +97,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Bool));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Bool)));
                         #else
@@ -194,7 +194,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -291,7 +291,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else
@@ -407,7 +407,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -523,7 +523,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else

--- a/backends/csharp/tests/output_unity/Assets/Interop.common.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.common.cs.expected
@@ -97,7 +97,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Bool));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Bool)));
                         #else
@@ -194,7 +194,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -291,7 +291,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else
@@ -407,7 +407,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -523,7 +523,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs
@@ -1226,7 +1226,7 @@ namespace My.Company
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Vec3f32));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Vec3f32)));
                         #else

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
@@ -1226,7 +1226,7 @@ namespace My.Company
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Vec3f32));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Vec3f32)));
                         #else

--- a/backends/csharp/tests/output_unsafe/Interop.common.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.common.cs
@@ -97,7 +97,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Bool));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Bool)));
                         #else
@@ -194,7 +194,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -291,7 +291,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else
@@ -407,7 +407,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -523,7 +523,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else

--- a/backends/csharp/tests/output_unsafe/Interop.common.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.common.cs.expected
@@ -97,7 +97,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Bool));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Bool)));
                         #else
@@ -194,7 +194,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -291,7 +291,7 @@ namespace My.Company.Common
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else
@@ -407,7 +407,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(uint));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(uint)));
                         #else
@@ -523,7 +523,7 @@ namespace My.Company.Common
                     {
                         #if __FALSE
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(byte));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(byte)));
                         #else

--- a/backends/csharp/tests/output_unsafe/Interop.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.cs
@@ -1226,7 +1226,7 @@ namespace My.Company
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Vec3f32));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Vec3f32)));
                         #else

--- a/backends/csharp/tests/output_unsafe/Interop.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.cs.expected
@@ -1226,7 +1226,7 @@ namespace My.Company
                     {
                         #if __INTEROPTOPUS_NEVER
                         #elif NETCOREAPP
-                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint)len);
+                        Unsafe.CopyBlock(dst, data.ToPointer(), (uint) len * (uint) sizeof(Vec3f32));
                         #elif UNITY_2018_1_OR_NEWER
                         UnsafeUtility.MemCpy(dst, data.ToPointer(), (long) (len * (ulong) sizeof(Vec3f32)));
                         #else

--- a/backends/csharp/tests/output_unsafe/Test.cs
+++ b/backends/csharp/tests/output_unsafe/Test.cs
@@ -9,7 +9,7 @@ namespace interop_test
         [Fact]
         public void pattern_ffi_slice_delegate()
         {
-            Interop.pattern_ffi_slice_delegate(delegate (Sliceu8 x0)
+            Interop.pattern_ffi_slice_delegate(delegate(Sliceu8 x0)
             {
                 var span = x0.ReadOnlySpan;
 
@@ -17,6 +17,18 @@ namespace interop_test
             });
         }
 
+        // Ensure that the Copied property has the correct length and contents 
+        [Fact]
+        public void ensure_unsafe_copy_length()
+        {
+            const int size = 20;
+            var service = SimpleService.NewWith(20);
+            var res = service.ReturnSliceMut();
 
+            foreach (var r in res.Copied)
+            {
+                Assert.True(r == size);
+            }
+        }
     }
 }


### PR DESCRIPTION
The existing implementation of unsafe copy in C# did not correctly copy the whole length of the array due to omitting the size of the type during the copy operation.