### PR TITLE
Fixed typo bug in FnPointer type_info method

### DIFF
--- a/core/src/lang/rust.rs
+++ b/core/src/lang/rust.rs
@@ -232,7 +232,7 @@ where
 {
     fn type_info() -> CType {
         let sig = FunctionSignature::new(
-            vec![Parameter::new("x0".to_string(), T1::type_info()), Parameter::new("x1".to_string(), T1::type_info())],
+            vec![Parameter::new("x0".to_string(), T1::type_info()), Parameter::new("x1".to_string(), T2::type_info())],
             R::type_info(),
         );
         CType::FnPointer(FnPointerType::new(sig))
@@ -247,7 +247,7 @@ where
 {
     fn type_info() -> CType {
         let sig = FunctionSignature::new(
-            vec![Parameter::new("x0".to_string(), T1::type_info()), Parameter::new("x1".to_string(), T1::type_info())],
+            vec![Parameter::new("x0".to_string(), T1::type_info()), Parameter::new("x1".to_string(), T2::type_info())],
             R::type_info(),
         );
         CType::FnPointer(FnPointerType::new(sig))
@@ -265,8 +265,8 @@ where
         let sig = FunctionSignature::new(
             vec![
                 Parameter::new("x0".to_string(), T1::type_info()),
-                Parameter::new("x1".to_string(), T1::type_info()),
-                Parameter::new("x2".to_string(), T2::type_info()),
+                Parameter::new("x1".to_string(), T2::type_info()),
+                Parameter::new("x2".to_string(), T3::type_info()),
             ],
             R::type_info(),
         );
@@ -285,8 +285,8 @@ where
         let sig = FunctionSignature::new(
             vec![
                 Parameter::new("x0".to_string(), T1::type_info()),
-                Parameter::new("x1".to_string(), T1::type_info()),
-                Parameter::new("x2".to_string(), T2::type_info()),
+                Parameter::new("x1".to_string(), T2::type_info()),
+                Parameter::new("x2".to_string(), T3::type_info()),
             ],
             R::type_info(),
         );


### PR DESCRIPTION
Fixed bug whereby incorrect signatures would be generated for FnPointer types with more than one parameter due to typo in type_info method.