### PR TITLE
Modified sort_types_by_dependencies to prevent infinite loop for missing types

### DIFF
--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -42,7 +42,9 @@ pub fn sort_types_by_dependencies(mut types: Vec<CType>) -> Vec<CType> {
 
         for t in &types {
             let embedded = t.embedded_types();
-            let all_exist = embedded.iter().all(|x| rval.contains(x));
+            let all_exist = embedded.iter().all(|x| {
+                rval.contains(x) || !types.contains(x)
+            });
 
             if embedded.is_empty() || all_exist {
                 this_round.push(t.clone());


### PR DESCRIPTION
The `sort_types_by_dependencies` function could cause an infinite loop in a case where a type's embedded types contained a type which was not present in the inventory (which can occur as a result of filtering the inventory using the `filter` method). I have modified the function to prevent this by checking if the type was at all present in the original list of types.