### PR TITLE
Only use Span and ReadOnlySpan for supported .NET versions

### DIFF
--- a/backends/csharp/benches/Interop.common.cs
+++ b/backends/csharp/benches/Interop.common.cs
@@ -54,6 +54,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Bool> ReadOnlySpan
         {
             get
@@ -64,6 +65,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceBool(NativeArray<Bool> handle)
         {
@@ -151,6 +153,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -161,6 +164,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu32(NativeArray<uint> handle)
         {
@@ -248,6 +252,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -258,6 +263,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu8(NativeArray<byte> handle)
         {
@@ -345,6 +351,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -355,6 +362,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu32(NativeArray<uint> handle)
         {
@@ -365,6 +373,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<uint> Span
         {
             get
@@ -375,6 +384,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public uint this[int i]
         {
             get
@@ -461,6 +471,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -471,6 +482,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu8(NativeArray<byte> handle)
         {
@@ -481,6 +493,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<byte> Span
         {
             get
@@ -491,6 +504,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public byte this[int i]
         {
             get

--- a/backends/csharp/benches/Interop.cs
+++ b/backends/csharp/benches/Interop.cs
@@ -1101,6 +1101,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<UseAsciiStringPattern> ReadOnlySpan
         {
             get
@@ -1111,6 +1112,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceUseAsciiStringPattern(NativeArray<UseAsciiStringPattern> handle)
         {
@@ -1183,6 +1185,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Vec3f32> ReadOnlySpan
         {
             get
@@ -1193,6 +1196,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceVec3f32(NativeArray<Vec3f32> handle)
         {

--- a/backends/csharp/src/overloads/dotnet.rs
+++ b/backends/csharp/src/overloads/dotnet.rs
@@ -258,6 +258,7 @@ impl OverloadWriter for DotNet {
 
     fn write_pattern_slice_overload(&self, w: &mut IndentWriter, h: Helper, _context_type_name: &str, type_string: &str) -> Result<(), Error> {
         if h.config.use_unsafe.any_unsafe() {
+            indented!(w, [_], r#"#if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)"#)?;
             indented!(w, [_], r#"public ReadOnlySpan<{}> ReadOnlySpan"#, type_string)?;
             indented!(w, [_], r#"{{"#)?;
             indented!(w, [_ _], r#"get"#)?;
@@ -268,12 +269,14 @@ impl OverloadWriter for DotNet {
             indented!(w, [_ _ _], r#"}}"#)?;
             indented!(w, [_ _], r#"}}"#)?;
             indented!(w, [_], r#"}}"#)?;
+            indented!(w, [_], r#"#endif"#)?;
         }
         Ok(())
     }
 
     fn write_pattern_slice_mut_overload(&self, w: &mut IndentWriter, h: Helper, _context_type_name: &str, type_string: &str) -> Result<(), Error> {
         if h.config.use_unsafe.any_unsafe() {
+            indented!(w, [_], r#"#if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)"#)?;
             indented!(w, [_], r#"public Span<{}> Span"#, type_string)?;
             indented!(w, [_], r#"{{"#)?;
             indented!(w, [_ _], r#"get"#)?;
@@ -284,6 +287,7 @@ impl OverloadWriter for DotNet {
             indented!(w, [_ _ _], r#"}}"#)?;
             indented!(w, [_ _], r#"}}"#)?;
             indented!(w, [_], r#"}}"#)?;
+            indented!(w, [_], r#"#endif"#)?;
         }
         Ok(())
     }

--- a/backends/csharp/tests/output_unity/Assets/Interop.common.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.common.cs
@@ -54,6 +54,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Bool> ReadOnlySpan
         {
             get
@@ -64,6 +65,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceBool(NativeArray<Bool> handle)
         {
@@ -151,6 +153,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -161,6 +164,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu32(NativeArray<uint> handle)
         {
@@ -248,6 +252,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -258,6 +263,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu8(NativeArray<byte> handle)
         {
@@ -345,6 +351,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -355,6 +362,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu32(NativeArray<uint> handle)
         {
@@ -365,6 +373,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<uint> Span
         {
             get
@@ -375,6 +384,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public uint this[int i]
         {
             get
@@ -461,6 +471,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -471,6 +482,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu8(NativeArray<byte> handle)
         {
@@ -481,6 +493,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<byte> Span
         {
             get
@@ -491,6 +504,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public byte this[int i]
         {
             get

--- a/backends/csharp/tests/output_unity/Assets/Interop.common.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.common.cs.expected
@@ -54,6 +54,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Bool> ReadOnlySpan
         {
             get
@@ -64,6 +65,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceBool(NativeArray<Bool> handle)
         {
@@ -151,6 +153,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -161,6 +164,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu32(NativeArray<uint> handle)
         {
@@ -248,6 +252,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -258,6 +263,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu8(NativeArray<byte> handle)
         {
@@ -345,6 +351,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -355,6 +362,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu32(NativeArray<uint> handle)
         {
@@ -365,6 +373,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<uint> Span
         {
             get
@@ -375,6 +384,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public uint this[int i]
         {
             get
@@ -461,6 +471,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -471,6 +482,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu8(NativeArray<byte> handle)
         {
@@ -481,6 +493,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<byte> Span
         {
             get
@@ -491,6 +504,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public byte this[int i]
         {
             get

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs
@@ -1101,6 +1101,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<UseAsciiStringPattern> ReadOnlySpan
         {
             get
@@ -1111,6 +1112,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceUseAsciiStringPattern(NativeArray<UseAsciiStringPattern> handle)
         {
@@ -1183,6 +1185,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Vec3f32> ReadOnlySpan
         {
             get
@@ -1193,6 +1196,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceVec3f32(NativeArray<Vec3f32> handle)
         {

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
@@ -1101,6 +1101,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<UseAsciiStringPattern> ReadOnlySpan
         {
             get
@@ -1111,6 +1112,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceUseAsciiStringPattern(NativeArray<UseAsciiStringPattern> handle)
         {
@@ -1183,6 +1185,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Vec3f32> ReadOnlySpan
         {
             get
@@ -1193,6 +1196,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceVec3f32(NativeArray<Vec3f32> handle)
         {

--- a/backends/csharp/tests/output_unsafe/Interop.common.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.common.cs
@@ -54,6 +54,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Bool> ReadOnlySpan
         {
             get
@@ -64,6 +65,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceBool(NativeArray<Bool> handle)
         {
@@ -151,6 +153,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -161,6 +164,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu32(NativeArray<uint> handle)
         {
@@ -248,6 +252,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -258,6 +263,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu8(NativeArray<byte> handle)
         {
@@ -345,6 +351,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -355,6 +362,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu32(NativeArray<uint> handle)
         {
@@ -365,6 +373,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<uint> Span
         {
             get
@@ -375,6 +384,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public uint this[int i]
         {
             get
@@ -461,6 +471,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -471,6 +482,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu8(NativeArray<byte> handle)
         {
@@ -481,6 +493,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<byte> Span
         {
             get
@@ -491,6 +504,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public byte this[int i]
         {
             get

--- a/backends/csharp/tests/output_unsafe/Interop.common.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.common.cs.expected
@@ -54,6 +54,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Bool> ReadOnlySpan
         {
             get
@@ -64,6 +65,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceBool(NativeArray<Bool> handle)
         {
@@ -151,6 +153,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -161,6 +164,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu32(NativeArray<uint> handle)
         {
@@ -248,6 +252,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -258,6 +263,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public Sliceu8(NativeArray<byte> handle)
         {
@@ -345,6 +351,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<uint> ReadOnlySpan
         {
             get
@@ -355,6 +362,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu32(NativeArray<uint> handle)
         {
@@ -365,6 +373,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<uint> Span
         {
             get
@@ -375,6 +384,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public uint this[int i]
         {
             get
@@ -461,6 +471,7 @@ namespace My.Company.Common
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<byte> ReadOnlySpan
         {
             get
@@ -471,6 +482,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceMutu8(NativeArray<byte> handle)
         {
@@ -481,6 +493,7 @@ namespace My.Company.Common
             }
         }
         #endif
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public Span<byte> Span
         {
             get
@@ -491,6 +504,7 @@ namespace My.Company.Common
                 }
             }
         }
+        #endif
         public byte this[int i]
         {
             get

--- a/backends/csharp/tests/output_unsafe/Interop.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.cs
@@ -1101,6 +1101,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<UseAsciiStringPattern> ReadOnlySpan
         {
             get
@@ -1111,6 +1112,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceUseAsciiStringPattern(NativeArray<UseAsciiStringPattern> handle)
         {
@@ -1183,6 +1185,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Vec3f32> ReadOnlySpan
         {
             get
@@ -1193,6 +1196,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceVec3f32(NativeArray<Vec3f32> handle)
         {

--- a/backends/csharp/tests/output_unsafe/Interop.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.cs.expected
@@ -1101,6 +1101,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<UseAsciiStringPattern> ReadOnlySpan
         {
             get
@@ -1111,6 +1112,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceUseAsciiStringPattern(NativeArray<UseAsciiStringPattern> handle)
         {
@@ -1183,6 +1185,7 @@ namespace My.Company
             this.data = handle;
             this.len = count;
         }
+        #if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
         public ReadOnlySpan<Vec3f32> ReadOnlySpan
         {
             get
@@ -1193,6 +1196,7 @@ namespace My.Company
                 }
             }
         }
+        #endif
         #if UNITY_2018_1_OR_NEWER
         public SliceVec3f32(NativeArray<Vec3f32> handle)
         {


### PR DESCRIPTION
The Span and ReadOnlySpan types are only supported in newer .NET versions (see [here](https://docs.microsoft.com/en-us/dotnet/api/system.readonlyspan-1?view=net-6.0#applies-to)). 

This change puts them behind the [.NET version preprocessor directives](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives) for the versions they support.