### PR TITLE
Only run test on supported .NET versions

### DIFF
--- a/backends/csharp/tests/output_unsafe/Test.cs
+++ b/backends/csharp/tests/output_unsafe/Test.cs
@@ -9,15 +9,17 @@ namespace interop_test
         [Fact]
         public void pattern_ffi_slice_delegate()
         {
+#if (NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER || NETCOREAPP2_1_OR_GREATER)
             Interop.pattern_ffi_slice_delegate(delegate(Sliceu8 x0)
             {
                 var span = x0.ReadOnlySpan;
 
                 return span[0];
             });
+#endif
         }
 
-        // Ensure that the Copied property has the correct length and contents 
+        // Ensure that the Copied property has the correct length and contents
         [Fact]
         public void ensure_unsafe_copy_length()
         {


### PR DESCRIPTION
This fixes an issue created by #45 which caused the C# unit tests to fail on older .NET versions,