### PR TITLE
Attribute to skip methods in a service

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -172,7 +172,7 @@ pub use error::Error;
 pub use generators::Interop;
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))] // does this work?
-pub use interoptopus_proc::{ffi_constant, ffi_function, ffi_service, ffi_service_ctor, ffi_service_method, ffi_surrogates, ffi_type};
+pub use interoptopus_proc::{ffi_constant, ffi_function, ffi_service, ffi_service_ctor, ffi_service_method, ffi_service_skip, ffi_surrogates, ffi_type};
 
 mod core;
 mod error;

--- a/proc_macros/src/lib.rs
+++ b/proc_macros/src/lib.rs
@@ -444,6 +444,19 @@ pub fn ffi_service_method(_attr: TokenStream, item: TokenStream) -> TokenStream 
     item
 }
 
+/// Inside a [`#[ffi_service]`](macro@crate::ffi_service) block, provide instruction to skip functions.
+///
+/// This is an optional attribute that can be applied to some methods.
+///
+/// Public functions with this attribute will not be included in the bindings.
+///
+/// See the [service module](https://docs.rs/interoptopus/latest/interoptopus/patterns/service/index.html) for an introduction into services.
+///
+#[proc_macro_attribute]
+pub fn ffi_service_skip(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
 /// On methods and structs, provide a type helper for foreign types.<sup>⚠️</sup>
 ///
 /// When dealing with types outside of your control you will not be able to implement [`CTypeInfo`](https://docs.rs/interoptopus/latest/interoptopus/lang/rust/trait.CTypeInfo.html) for them.

--- a/proc_macros/src/service.rs
+++ b/proc_macros/src/service.rs
@@ -35,8 +35,11 @@ pub fn ffi_service(attr: AttributeArgs, input: TokenStream) -> TokenStream {
         if let ImplItem::Method(method) = impl_item {
             match &method.vis {
                 Visibility::Public(_) => {
-                    if let Some(descriptor) = generate_service_method(&attributes, &item, method) {
-                        function_descriptors.push(descriptor);
+                    if method.attrs.iter().any(|x| format!("{:?}", x).contains("ffi_service_skip")) {}
+                    else {
+                        if let Some(descriptor) = generate_service_method(&attributes, &item, method) {
+                            function_descriptors.push(descriptor);
+                        }
                     }
                 }
                 _ => {}


### PR DESCRIPTION
This provides an additional _service_ attribute to skip certain methods. Practical if the API is used both in Rust and external languages.