### PR TITLE
Create C# documentation writer

### DIFF
--- a/backends/cpython/src/docs.rs
+++ b/backends/cpython/src/docs.rs
@@ -1,8 +1,7 @@
-use crate::writer::WriteFor;
 use crate::{DocConfig, PythonWriter};
 use interoptopus::lang::c::{CType, CompositeType, Function};
 use interoptopus::patterns::{LibraryPattern, TypePattern};
-use interoptopus::writer::IndentWriter;
+use interoptopus::writer::{IndentWriter, WriteFor};
 use interoptopus::{indented, non_service_functions};
 use interoptopus::{Error, Inventory};
 use std::fs::File;

--- a/backends/cpython/src/writer.rs
+++ b/backends/cpython/src/writer.rs
@@ -4,15 +4,8 @@ use interoptopus::lang::c::{CType, CompositeType, EnumType, Function, PrimitiveT
 use interoptopus::patterns::service::Service;
 use interoptopus::patterns::{LibraryPattern, TypePattern};
 use interoptopus::util::{longest_common_prefix, safe_name, sort_types_by_dependencies};
-use interoptopus::writer::IndentWriter;
+use interoptopus::writer::{IndentWriter, WriteFor};
 use interoptopus::{indented, non_service_functions, Error, Inventory};
-
-/// In some places we can write for docs or for actual code generation.
-#[derive(PartialOrd, PartialEq, Copy, Clone, Debug)]
-pub enum WriteFor {
-    Code,
-    Docs,
-}
 
 /// Writes the Python file format, `impl` this trait to customize output.
 pub trait PythonWriter {

--- a/backends/csharp/benches/Interop.cs
+++ b/backends/csharp/benches/Interop.cs
@@ -39,72 +39,44 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void")]
         public static extern void primitive_void();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void2")]
         public static extern void primitive_void2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_bool")]
         public static extern bool primitive_bool(bool x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u8")]
         public static extern byte primitive_u8(byte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u16")]
         public static extern ushort primitive_u16(ushort x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u32")]
         public static extern uint primitive_u32(uint x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u64")]
         public static extern ulong primitive_u64(ulong x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i8")]
         public static extern sbyte primitive_i8(sbyte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i16")]
         public static extern short primitive_i16(short x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i32")]
         public static extern int primitive_i32(int x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i64")]
         public static extern long primitive_i64(long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_5")]
         public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_10")]
         public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr")]
         public static extern IntPtr ptr(ref long x);
-
-
 
         /// # Safety
         ///
@@ -112,37 +84,23 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
         public static extern IntPtr ptr_mut(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_simple")]
         public static extern IntPtr ref_simple(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
         public static extern IntPtr ref_mut_simple(out long x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
         public static extern bool ref_mut_option(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_1")]
         public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
@@ -155,15 +113,11 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_2")]
         public static extern IntPtr complex_args_2(SomeForeignType cmplx);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(IntPtr callback, byte value);
@@ -172,63 +126,39 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1a")]
         public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1b")]
         public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1c")]
         public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_2")]
         public static extern byte generic_2(IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_3")]
         public static extern byte generic_3(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_4")]
         public static extern byte generic_4(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "array_1")]
         public static extern byte array_1(Array x);
-
-
 
         /// This function has documentation.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "documented")]
         public static extern EnumDocumented documented(StructDocumented x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_1")]
         public static extern Vec1 ambiguous_1(Vec1 x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_2")]
         public static extern Vec2 ambiguous_2(Vec2 x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_3")]
         public static extern bool ambiguous_3(Vec1 x, Vec2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespaced_type")]
         public static extern Vec namespaced_type(Vec x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "panics")]
         public static extern FFIError panics();
@@ -241,51 +171,32 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed")]
         public static extern EnumRenamed renamed(StructRenamed x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "sleep")]
         public static extern void sleep(ulong millis);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "weird_1")]
         public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "visibility")]
         public static extern void visibility(Visibility1 x, Visibility2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "repr_transparent")]
         public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_1")]
         public static extern uint pattern_ascii_pointer_1(string x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_2")]
         public static extern IntPtr pattern_ascii_pointer_2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_len")]
         public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
@@ -432,14 +343,12 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(IntPtr callback);
 
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(IntPtr callback);
@@ -448,26 +357,17 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_1")]
         public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_2")]
         public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_bool")]
         public static extern Bool pattern_ffi_bool(Bool ffi_bool);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_api_guard")]
         public static extern ulong pattern_api_guard();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(MyCallback callback, uint x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(IntPtr callback, uint x);
@@ -475,7 +375,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(IntPtr callback);
@@ -504,7 +403,6 @@ namespace My.Company
             }
         }
 
-
         /// The constructor must return a `Result<Self, Error>`.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with")]
         public static extern FFIError simple_service_new_with(ref IntPtr context, uint some_value);
@@ -518,7 +416,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_without")]
         public static extern FFIError simple_service_new_without(ref IntPtr context);
 
@@ -529,7 +426,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with_string")]
         public static extern FFIError simple_service_new_with_string(ref IntPtr context, string ascii);
@@ -542,7 +438,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_failing")]
         public static extern FFIError simple_service_new_failing(ref IntPtr context, byte some_value);
 
@@ -553,7 +448,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         /// Methods returning a Result<(), _> are the default and do not
         /// need annotations.
@@ -570,19 +464,14 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_value")]
         public static extern uint simple_service_method_value(IntPtr context, uint x);
-
-
 
         /// This method should be documented.
         ///
         /// Multiple lines.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void")]
         public static extern void simple_service_method_void(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self")]
         public static extern byte simple_service_method_mut_self(IntPtr context, Sliceu8 slice);
@@ -631,8 +520,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
         public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
         public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
@@ -744,20 +631,14 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice")]
         public static extern Sliceu32 simple_service_return_slice(IntPtr context);
 
-
-
         /// Warning, you _must_ discard the returned slice object before calling into this service
         /// again, as otherwise undefined behavior might happen.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice_mut")]
         public static extern SliceMutu32 simple_service_return_slice_mut(IntPtr context);
 
-
-
         /// This function has no panic safeguards. If it panics your host app will be in an undefined state.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_string")]
         public static extern IntPtr simple_service_return_string(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void_ffi_error")]
         public static extern FFIError simple_service_method_void_ffi_error(IntPtr context);
@@ -769,7 +650,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_callback")]
         public static extern FFIError simple_service_method_callback(IntPtr context, MyCallback callback);
@@ -809,7 +689,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_new_with")]
         public static extern FFIError simple_service_lt_new_with(ref IntPtr context, ref uint some_value);
 
@@ -820,7 +699,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_method_lt")]
         public static extern void simple_service_lt_method_lt(IntPtr context, SliceBool slice);
@@ -897,7 +775,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
     }
 

--- a/backends/csharp/src/config.rs
+++ b/backends/csharp/src/config.rs
@@ -114,3 +114,10 @@ impl Default for Config {
         }
     }
 }
+
+/// Configures C# documentation generation.
+#[derive(Clone, Debug, Default)]
+pub struct DocConfig {
+    /// Header to append to the generated documentation.
+    pub header: String,
+}

--- a/backends/csharp/src/converter.rs
+++ b/backends/csharp/src/converter.rs
@@ -10,6 +10,16 @@ use interoptopus::util::safe_name;
 #[derive(Copy, Clone)]
 pub struct Converter {}
 
+/// How to convert from Rust function names to C#
+pub enum FunctionNameFlavor<'a> {
+    /// Takes the name as it is written in Rust
+    RawFFIName,
+    /// Converts the name to camel case
+    CSharpMethodNameWithClass,
+    /// Converts the name to camel case and removes the class name
+    CSharpMethodNameWithoutClass(&'a str),
+}
+
 /// Converts Interoptopus types to C# types.
 pub trait CSharpTypeConverter {
     /// Converts a primitive (Rust) type to a native C# type name, e.g., `f32` to `float`.
@@ -200,11 +210,12 @@ pub trait CSharpTypeConverter {
         self.to_typespecifier_in_rval(function.signature().rval())
     }
 
-    fn function_name_to_csharp_name(&self, function: &Function, rename_symbols: bool) -> String {
-        if rename_symbols {
-            function.name().to_upper_camel_case()
-        } else {
-            function.name().to_string()
+    /// Gets the function name in a specific flavor
+    fn function_name_to_csharp_name(&self, function: &Function, flavor: FunctionNameFlavor) -> String {
+        match flavor {
+            FunctionNameFlavor::RawFFIName => function.name().to_string(),
+            FunctionNameFlavor::CSharpMethodNameWithClass => function.name().to_upper_camel_case(),
+            FunctionNameFlavor::CSharpMethodNameWithoutClass(class) => function.name().replace(class, "").to_upper_camel_case(),
         }
     }
 }

--- a/backends/csharp/src/docs.rs
+++ b/backends/csharp/src/docs.rs
@@ -1,0 +1,337 @@
+use crate::{CSharpWriter};
+use interoptopus::lang::c::{CType, CompositeType, Function};
+use interoptopus::patterns::{LibraryPattern, TypePattern};
+use interoptopus::writer::{IndentWriter, WriteFor};
+use interoptopus::{indented, non_service_functions};
+use interoptopus::{Error, Inventory};
+use std::fs::File;
+use std::path::Path;
+use crate::config::DocConfig;
+use crate::converter::{CSharpTypeConverter, FunctionNameFlavor};
+
+pub struct DocGenerator<'a, W> {
+    inventory: &'a Inventory,
+    csharp_writer: &'a W,
+    doc_config: DocConfig,
+}
+
+impl<'a, W: CSharpWriter> DocGenerator<'a, W> {
+    pub fn new(inventory: &'a Inventory, w: &'a W, config: DocConfig) -> Self {
+        Self {
+            inventory,
+            csharp_writer: w,
+            doc_config: config,
+        }
+    }
+
+    pub fn inventory(&self) -> &Inventory {
+        &self.inventory
+    }
+
+    pub fn config(&self) -> &DocConfig {
+        &self.doc_config
+    }
+
+    pub fn write_toc(&self, w: &mut IndentWriter) -> Result<(), Error> {
+        indented!(w, r#"## API Overview"#)?;
+
+        w.newline()?;
+        indented!(w, r#"### Functions"#)?;
+        indented!(w, r#"Freestanding callables inside the module."#)?;
+
+        for the_type in non_service_functions(self.inventory) {
+            let doc = the_type.meta().documentation().lines().first().cloned().unwrap_or_default();
+
+            indented!(w, r#" - **[{}](#{})** - {}"#, the_type.name(), the_type.name(), doc)?;
+        }
+
+        w.newline()?;
+        indented!(w, r#"### Classes"#)?;
+        indented!(w, r#"Methods operating on common state."#)?;
+
+        for pattern in self.inventory.patterns().iter().filter_map(|x| match x {
+            LibraryPattern::Service(s) => Some(s),
+        }) {
+            let prefix = pattern.common_prefix();
+            let doc = pattern.the_type().meta().documentation().lines().first().cloned().unwrap_or_default();
+            let name = pattern.the_type().rust_name();
+
+            indented!(w, r#" - **[{}](#{})** - {}"#, name, name, doc)?;
+
+            for x in pattern.constructors() {
+                let func_name =  self.csharp_writer.converter().function_name_to_csharp_name(x, FunctionNameFlavor::CSharpMethodNameWithoutClass(&prefix));
+                let target = format!("{}.{}", name, func_name);
+                let doc = x.meta().documentation().lines().first().cloned().unwrap_or_default();
+                indented!(w, r#"     - **[{}](#{})** <sup>**ctor**</sup> - {}"#, func_name, target, doc)?;
+            }
+            for x in pattern.methods() {
+                let func_name =  self.csharp_writer.converter().function_name_to_csharp_name(x, FunctionNameFlavor::CSharpMethodNameWithoutClass(&prefix));
+                let target = format!("{}.{}", name, func_name);
+                let doc = x.meta().documentation().lines().first().cloned().unwrap_or_default();
+                indented!(w, r#"     - **[{}](#{})** - {}"#, func_name, target, doc)?;
+            }
+        }
+
+        w.newline()?;
+        indented!(w, r#"### Enums"#)?;
+        indented!(w, r#"Groups of related constants."#)?;
+
+        for the_type in self.inventory.ctypes().iter().filter_map(|x| match x {
+            CType::Enum(e) => Some(e),
+            _ => None,
+        }) {
+            let doc = the_type.meta().documentation().lines().first().cloned().unwrap_or_default();
+            indented!(w, r#" - **[{}](#{})** - {}"#, the_type.rust_name(), the_type.rust_name(), doc)?;
+        }
+
+        w.newline()?;
+        indented!(w, r#"### Data Structs"#)?;
+        indented!(w, r#"Composite data used by functions and methods."#)?;
+
+        for the_type in self.inventory.ctypes().iter() {
+            match the_type {
+                CType::Composite(c) => {
+                    let doc = c.meta().documentation().lines().first().cloned().unwrap_or_default();
+                    indented!(w, r#" - **[{}](#{})** - {}"#, c.rust_name(), c.rust_name(), doc)?;
+                }
+                CType::Pattern(p @ TypePattern::Option(_)) => {
+                    let c = p.fallback_type().as_composite_type().cloned().unwrap();
+                    indented!(w, r#" - **[{}](#{})** - A boolean flag and optionally data."#, c.rust_name(), c.rust_name())?;
+                }
+                CType::Pattern(p @ TypePattern::Slice(_)) => {
+                    let c = p.fallback_type().as_composite_type().cloned().unwrap();
+                    indented!(w, r#" - **[{}](#{})** - A pointer and length of un-owned elements."#, c.rust_name(), c.rust_name())?;
+                }
+                _ => continue,
+            }
+        }
+
+        w.newline()?;
+        indented!(w, r#"---"#)?;
+        w.newline()?;
+
+        Ok(())
+    }
+
+    pub fn write_types(&self, w: &mut IndentWriter) -> Result<(), Error> {
+        indented!(w, r#"# Types "#)?;
+
+        for the_type in self.inventory().ctypes() {
+            match the_type {
+                CType::Composite(e) => self.write_composite(w, e)?,
+                CType::Pattern(p @ TypePattern::Option(_)) => self.write_composite(w, p.fallback_type().as_composite_type().unwrap())?,
+                CType::Pattern(p @ TypePattern::Slice(_)) => self.write_composite(w, p.fallback_type().as_composite_type().unwrap())?,
+                _ => continue,
+            };
+
+            w.newline()?;
+            indented!(w, r#"---"#)?;
+            w.newline()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn write_composite(&self, w: &mut IndentWriter, composite: &CompositeType) -> Result<(), Error> {
+        let meta = composite.meta();
+
+        w.newline()?;
+        w.newline()?;
+
+        indented!(w, r#" ### <a name="{}">**{}**</a>"#, composite.rust_name(), composite.rust_name())?;
+        w.newline()?;
+
+        for line in meta.documentation().lines() {
+            indented!(w, r#"{}"#, line.trim())?;
+        }
+
+        w.newline()?;
+
+        indented!(w, r#"#### Fields "#)?;
+        for f in composite.fields() {
+            let doc = f.documentation().lines().join("\n");
+            indented!(w, r#"- **{}** - {} "#, f.name(), doc)?;
+        }
+
+        indented!(w, r#"#### Definition "#)?;
+        indented!(w, r#"```csharp"#)?;
+        self.csharp_writer.write_type_definition_composite_body(w, &composite, WriteFor::Docs)?;
+        indented!(w, r#"```"#)?;
+
+        Ok(())
+    }
+
+    pub fn write_enums(&self, w: &mut IndentWriter) -> Result<(), Error> {
+        indented!(w, r#"# Enums "#)?;
+
+        for the_type in self.inventory().ctypes() {
+            let the_enum = match the_type {
+                CType::Enum(e) => e,
+                _ => continue,
+            };
+
+            let meta = the_enum.meta();
+
+            w.newline()?;
+            w.newline()?;
+
+            indented!(w, r#" ### <a name="{}">**{}**</a>"#, the_type.name_within_lib(), the_type.name_within_lib())?;
+            w.newline()?;
+
+            for line in meta.documentation().lines() {
+                indented!(w, r#"{}"#, line.trim())?;
+            }
+            w.newline()?;
+
+            indented!(w, r#"#### Variants "#)?;
+            for v in the_enum.variants() {
+                let doc = v.documentation().lines().join("\n");
+                indented!(w, r#"- **{}** - {} "#, v.name(), doc)?;
+            }
+
+            indented!(w, r#"#### Definition "#)?;
+            indented!(w, r#"```csharp"#)?;
+            self.csharp_writer.write_type_definition_enum(w, the_enum, WriteFor::Docs)?;
+            indented!(w, r#"```"#)?;
+            w.newline()?;
+            indented!(w, r#"---"#)?;
+            w.newline()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn write_functions(&self, w: &mut IndentWriter) -> Result<(), Error> {
+        indented!(w, r#"# Functions"#)?;
+
+        for the_type in non_service_functions(self.inventory()) {
+            self.write_function(w, the_type)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_function(&self, w: &mut IndentWriter, function: &Function) -> Result<(), Error> {
+        indented!(w, r#"### <a name="{}">**{}**</a>"#, function.name(), function.name())?;
+
+        for line in function.meta().documentation().lines() {
+            if line.trim().starts_with('#') {
+                write!(w.writer(), "##")?;
+            }
+            indented!(w, r#"{}"#, line.trim())?;
+        }
+
+        indented!(w, r#"#### Definition "#)?;
+        indented!(w, r#"```csharp"#)?;
+        self.csharp_writer.write_function(w, function, WriteFor::Docs)?;
+        indented!(w, r#"```"#)?;
+        w.newline()?;
+        indented!(w, r#"---"#)?;
+        w.newline()?;
+
+        Ok(())
+    }
+
+    pub fn write_services(&self, w: &mut IndentWriter) -> Result<(), Error> {
+        indented!(w, r#"# Classes"#)?;
+
+        for pattern in self.inventory.patterns().iter().filter_map(|x| match x {
+            LibraryPattern::Service(s) => Some(s),
+        }) {
+            let prefix = pattern.common_prefix();
+            let doc = pattern.the_type().meta().documentation().lines();
+            let class_name = pattern.the_type().rust_name();
+
+            indented!(w, r#"## <a name="{}">**{}**</a>"#, class_name, class_name)?;
+
+            for line in doc {
+                let line = line.replace(" # ", " #### ");
+                let line = line.replace(" ## ", " ##### ");
+                let line = line.replace(" ### ", " ###### ");
+
+                indented!(w, r#"{}"#, line)?;
+            }
+
+            for x in pattern.constructors() {
+                let fname =  self.csharp_writer.converter().function_name_to_csharp_name(x, FunctionNameFlavor::CSharpMethodNameWithoutClass(&prefix));
+                let target = format!("{}.{}", class_name, fname);
+                indented!(w, r#"### <a name="{}">**{}**</a> <sup>ctor</sup>"#, target, target)?;
+
+                let doc = x.meta().documentation().lines();
+                for line in doc {
+                    let line = line.replace(" # ", " #### ");
+                    let line = line.replace(" ## ", " ##### ");
+                    let line = line.replace(" ### ", " ###### ");
+                    indented!(w, r#"{}"#, line)?;
+                }
+                w.newline()?;
+                indented!(w, r#"#### Definition "#)?;
+                indented!(w, r#"```csharp"#)?;
+                self.csharp_writer.write_pattern_service_method(w, pattern, x, class_name, &fname, true, true, WriteFor::Docs)?;
+                indented!(w, r#"```"#)?;
+                w.newline()?;
+                indented!(w, r#"---"#)?;
+                w.newline()?;
+            }
+
+            for x in pattern.methods() {
+                let fname =  self.csharp_writer.converter().function_name_to_csharp_name(x, FunctionNameFlavor::CSharpMethodNameWithoutClass(&prefix));
+                let target = format!("{}.{}", class_name, fname);
+
+                let rval = match x.signature().rval() {
+                    CType::Pattern(TypePattern::FFIErrorEnum(_)) => "void".to_string(),
+                    CType::Pattern(TypePattern::AsciiPointer) => "string".to_string(),
+                    _ => self.csharp_writer.converter().to_typespecifier_in_rval(x.signature().rval()),
+                };
+
+                indented!(w, r#"### <a name="{}">**{}**</a>"#, target, target)?;
+
+                let doc = x.meta().documentation().lines();
+                for line in doc {
+                    let line = line.replace(" # ", " #### ");
+                    let line = line.replace(" ## ", " ##### ");
+                    let line = line.replace(" ### ", " ###### ");
+                    indented!(w, r#"{}"#, line)?;
+                }
+
+                w.newline()?;
+                indented!(w, r#"#### Definition "#)?;
+                indented!(w, r#"```csharp"#)?;
+                self.csharp_writer.write_pattern_service_method(w, pattern, x, &rval, &fname, false, false, WriteFor::Docs)?;
+                for overload in self.csharp_writer.overloads() {
+                    overload.write_service_method_overload(w, self.csharp_writer.helper(), pattern, x, &fname, WriteFor::Docs)?;
+                }
+                indented!(w, r#"```"#)?;
+                w.newline()?;
+                indented!(w, r#"---"#)?;
+                w.newline()?;
+            }
+
+            w.newline()?;
+            w.newline()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn write_to(&self, w: &mut IndentWriter) -> Result<(), Error> {
+        writeln!(w.writer(), "{}", self.config().header)?;
+
+        self.write_toc(w)?;
+        self.write_types(w)?;
+        self.write_enums(w)?;
+        self.write_functions(w)?;
+        self.write_services(w)?;
+
+        w.newline()?;
+
+        Ok(())
+    }
+
+    pub fn write_file<P: AsRef<Path>>(&self, file_name: P) -> Result<(), Error> {
+        let mut file = File::create(file_name)?;
+        let mut writer = IndentWriter::new(&mut file);
+
+        self.write_to(&mut writer)
+    }
+}

--- a/backends/csharp/src/lib.rs
+++ b/backends/csharp/src/lib.rs
@@ -124,11 +124,13 @@ mod converter;
 pub mod overloads;
 mod testing;
 mod writer;
+mod docs;
 
-pub use config::{CSharpVisibility, Config, Unsafe, WriteTypes};
+pub use config::{CSharpVisibility, Config, Unsafe, WriteTypes, DocConfig};
 pub use converter::{CSharpTypeConverter, Converter};
 pub use testing::run_dotnet_command_if_installed;
 pub use writer::CSharpWriter;
+pub use docs::DocGenerator;
 
 /// **Start here**, main converter implementing [`Interop`].
 pub struct Generator {

--- a/backends/csharp/src/overloads/dotnet.rs
+++ b/backends/csharp/src/overloads/dotnet.rs
@@ -1,5 +1,6 @@
 use crate::overloads::{write_common_service_method_overload, write_function_overloaded_invoke_with_error_handling, Helper};
 use crate::{OverloadWriter, Unsafe};
+use crate::converter::FunctionNameFlavor;
 use interoptopus::lang::c::{CType, CompositeType, Field, Function, FunctionSignature, Parameter};
 use interoptopus::patterns::service::Service;
 use interoptopus::patterns::TypePattern;
@@ -117,7 +118,10 @@ impl OverloadWriter for DotNet {
         let mut to_pin_name = Vec::new();
         let mut to_pin_slice_type = Vec::new();
         let mut to_invoke = Vec::new();
-        let raw_name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
+        let raw_name = h.converter.function_name_to_csharp_name(function, match h.config.rename_symbols {
+            true => FunctionNameFlavor::CSharpMethodNameWithClass,
+            false => FunctionNameFlavor::RawFFIName
+        });
         let this_name = if has_error_enum && !has_overload {
             format!("{}_checked", raw_name)
         } else {
@@ -193,7 +197,10 @@ impl OverloadWriter for DotNet {
                 }
             }
 
-            let fn_name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
+            let fn_name = h.converter.function_name_to_csharp_name(function, match h.config.rename_symbols {
+                true => FunctionNameFlavor::CSharpMethodNameWithClass,
+                false => FunctionNameFlavor::RawFFIName
+            });
             let call = format!(r#"{}({});"#, fn_name, to_invoke.join(", "));
 
             write_function_overloaded_invoke_with_error_handling(w, function, &call)?;
@@ -228,7 +235,10 @@ impl OverloadWriter for DotNet {
                 w.indent();
             }
 
-            let fn_name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
+            let fn_name = h.converter.function_name_to_csharp_name(function, match h.config.rename_symbols {
+                true => FunctionNameFlavor::CSharpMethodNameWithClass,
+                false => FunctionNameFlavor::RawFFIName
+            });
             let call = format!(r#"{}({});"#, fn_name, to_invoke.join(", "));
             write_function_overloaded_invoke_with_error_handling(w, function, &call)?;
 

--- a/backends/csharp/src/overloads/dotnet.rs
+++ b/backends/csharp/src/overloads/dotnet.rs
@@ -174,6 +174,7 @@ impl OverloadWriter for DotNet {
             params.push(format!("{} {}", native, name));
         }
 
+        w.newline()?;
         self.write_documentation(w, function.meta().documentation())?;
 
         indented!(w, r#"public static {} {}({}) {{"#, rval, this_name, params.join(", "))?;

--- a/backends/csharp/src/overloads/mod.rs
+++ b/backends/csharp/src/overloads/mod.rs
@@ -52,6 +52,7 @@
 
 use interoptopus::lang::c::{CType, CompositeType, Documentation, Field, Function, Parameter, PrimitiveType};
 use interoptopus::patterns::service::Service;
+use interoptopus::patterns::TypePattern;
 use interoptopus::writer::IndentWriter;
 use interoptopus::{indented, Error};
 
@@ -59,8 +60,8 @@ mod dotnet;
 mod unity;
 
 use crate::{CSharpTypeConverter, Config};
+use crate::converter::FunctionNameFlavor;
 pub use dotnet::DotNet;
-use interoptopus::patterns::TypePattern;
 pub use unity::Unity;
 
 #[doc(hidden)]
@@ -164,7 +165,10 @@ fn write_common_service_method_overload<FPatternMap: Fn(&Helper, &Parameter) -> 
         types.push(native);
     }
 
-    let method_to_invoke = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
+    let method_to_invoke = h.converter.function_name_to_csharp_name(function, match h.config.rename_symbols {
+        true => FunctionNameFlavor::CSharpMethodNameWithClass,
+        false => FunctionNameFlavor::RawFFIName
+    });
     let extra_args = if to_invoke.is_empty() {
         "".to_string()
     } else {

--- a/backends/csharp/src/overloads/mod.rs
+++ b/backends/csharp/src/overloads/mod.rs
@@ -53,7 +53,7 @@
 use interoptopus::lang::c::{CType, CompositeType, Documentation, Field, Function, Parameter, PrimitiveType};
 use interoptopus::patterns::service::Service;
 use interoptopus::patterns::TypePattern;
-use interoptopus::writer::IndentWriter;
+use interoptopus::writer::{IndentWriter, WriteFor};
 use interoptopus::{indented, Error};
 
 mod dotnet;
@@ -76,9 +76,9 @@ pub trait OverloadWriter {
 
     fn write_field_decorators(&self, w: &mut IndentWriter, h: Helper, field: &Field, strct: &CompositeType) -> Result<(), Error>;
 
-    fn write_function_overload(&self, w: &mut IndentWriter, h: Helper, function: &Function) -> Result<(), Error>;
+    fn write_function_overload(&self, w: &mut IndentWriter, h: Helper, function: &Function, write_for: WriteFor) -> Result<(), Error>;
 
-    fn write_service_method_overload(&self, w: &mut IndentWriter, h: Helper, class: &Service, function: &Function, fn_pretty: &str) -> Result<(), Error>;
+    fn write_service_method_overload(&self, w: &mut IndentWriter, h: Helper, class: &Service, function: &Function, fn_pretty: &str, write_for: WriteFor) -> Result<(), Error>;
 
     fn write_pattern_slice_overload(&self, w: &mut IndentWriter, h: Helper, context_type_name: &str, type_string: &str) -> Result<(), Error>;
 
@@ -129,6 +129,7 @@ fn write_common_service_method_overload<FPatternMap: Fn(&Helper, &Parameter) -> 
     function: &Function,
     fn_pretty: &str,
     f_pattern: FPatternMap,
+    write_for: WriteFor
 ) -> Result<(), Error> {
     let mut names = Vec::new();
     let mut to_invoke = Vec::new();
@@ -182,6 +183,11 @@ fn write_common_service_method_overload<FPatternMap: Fn(&Helper, &Parameter) -> 
 
     // Write signature.
     indented!(w, r#"public {} {}({})"#, rval, fn_pretty, arg_tokens.join(", "))?;
+
+    if write_for == WriteFor::Docs {
+        return Ok(());
+    }
+
     indented!(w, r#"{{"#)?;
 
     match function.signature().rval() {

--- a/backends/csharp/src/overloads/unity.rs
+++ b/backends/csharp/src/overloads/unity.rs
@@ -1,5 +1,6 @@
 use crate::overloads::{write_common_service_method_overload, write_function_overloaded_invoke_with_error_handling, Helper};
 use crate::{OverloadWriter, Unsafe};
+use crate::converter::FunctionNameFlavor;
 use interoptopus::lang::c::{CType, CompositeType, Field, Function, FunctionSignature, Parameter};
 use interoptopus::patterns::service::Service;
 use interoptopus::patterns::TypePattern;
@@ -108,7 +109,10 @@ impl Unity {
 
     fn write_function_delegate_overload_helper(&self, w: &mut IndentWriter, h: &Helper, function: &Function) -> Result<(), Error> {
         let rval = h.converter.function_rval_to_csharp_typename(function);
-        let name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
+        let name = h.converter.function_name_to_csharp_name(function, match h.config.rename_symbols {
+            true => FunctionNameFlavor::CSharpMethodNameWithClass,
+            false => FunctionNameFlavor::RawFFIName
+        });
 
         let mut params = Vec::new();
         for (_, p) in function.signature().params().iter().enumerate() {
@@ -195,7 +199,10 @@ impl OverloadWriter for Unity {
         let mut to_pin_name = Vec::new();
         let mut to_pin_slice_type = Vec::new();
         let mut to_invoke = Vec::new();
-        let raw_name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
+        let raw_name = h.converter.function_name_to_csharp_name(function, match h.config.rename_symbols {
+            true => FunctionNameFlavor::CSharpMethodNameWithClass,
+            false => FunctionNameFlavor::RawFFIName
+        });
         let this_name = if has_error_enum && !has_overload {
             format!("{}_checked", raw_name)
         } else {
@@ -260,7 +267,10 @@ impl OverloadWriter for Unity {
             }
         }
 
-        let fn_name = h.converter.function_name_to_csharp_name(function, h.config.rename_symbols);
+        let fn_name = h.converter.function_name_to_csharp_name(function, match h.config.rename_symbols {
+            true => FunctionNameFlavor::CSharpMethodNameWithClass,
+            false => FunctionNameFlavor::RawFFIName
+        });
         let call = format!(r#"{}({});"#, fn_name, to_invoke.join(", "));
         write_function_overloaded_invoke_with_error_handling(w, function, &call)?;
 

--- a/backends/csharp/src/overloads/unity.rs
+++ b/backends/csharp/src/overloads/unity.rs
@@ -177,6 +177,7 @@ impl OverloadWriter for Unity {
             return Ok(());
         }
 
+        w.newline()?;
         self.write_documentation(w, function.meta().documentation())?;
 
         // If we have delegates we need to write a version with IntPtr only

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -141,7 +141,6 @@ pub trait CSharpWriter {
         self.write_function_declaration(w, function)?;
 
         for overload in self.overloads() {
-            w.newline()?;
             overload.write_function_overload(w, self.helper(), function)?;
         }
 

--- a/backends/csharp/tests/backend_csharp_ui.rs
+++ b/backends/csharp/tests/backend_csharp_ui.rs
@@ -1,9 +1,10 @@
 use interoptopus::testing::assert_file_matches_generated;
 use interoptopus::util::NamespaceMappings;
-use interoptopus::Error;
-use interoptopus::Interop;
+use interoptopus::{Error, Interop};
 use interoptopus_backend_csharp::overloads::{DotNet, Unity};
-use interoptopus_backend_csharp::{run_dotnet_command_if_installed, CSharpVisibility, Config, Generator, Unsafe, WriteTypes};
+use interoptopus_backend_csharp::{
+    run_dotnet_command_if_installed, CSharpVisibility, Config, DocConfig, DocGenerator, Generator, Unsafe, WriteTypes
+};
 use std::path::{Path, PathBuf};
 use tempdir::TempDir;
 
@@ -68,6 +69,13 @@ fn generate_bindings_multi(folder: impl AsRef<Path>, use_unsafe: Unsafe, config:
     Ok(())
 }
 
+fn generate_documentation(output: &str) -> Result<(), Error> {
+    let inventory = interoptopus_reference_project::ffi_inventory();
+    let generator = Generator::new(Config::default(), inventory.clone());
+
+    DocGenerator::new(&inventory, &generator, DocConfig::default()).write_file(output)
+}
+
 #[test]
 #[cfg_attr(miri, ignore)]
 fn bindings_match_reference() -> Result<(), Error> {
@@ -83,6 +91,8 @@ fn bindings_match_reference() -> Result<(), Error> {
 
     assert_file_matches_generated("tests/output_unity/Assets/Interop.cs");
     assert_file_matches_generated("tests/output_unity/Assets/Interop.common.cs");
+
+    generate_documentation("tests/output/reference_project.md")?;
 
     Ok(())
 }

--- a/backends/csharp/tests/output/reference_project.md
+++ b/backends/csharp/tests/output/reference_project.md
@@ -1,0 +1,1374 @@
+
+## API Overview
+
+### Functions
+Freestanding callables inside the module.
+ - **[primitive_void](#primitive_void)** - 
+ - **[primitive_void2](#primitive_void2)** - 
+ - **[primitive_bool](#primitive_bool)** - 
+ - **[primitive_u8](#primitive_u8)** - 
+ - **[primitive_u16](#primitive_u16)** - 
+ - **[primitive_u32](#primitive_u32)** - 
+ - **[primitive_u64](#primitive_u64)** - 
+ - **[primitive_i8](#primitive_i8)** - 
+ - **[primitive_i16](#primitive_i16)** - 
+ - **[primitive_i32](#primitive_i32)** - 
+ - **[primitive_i64](#primitive_i64)** - 
+ - **[many_args_5](#many_args_5)** - 
+ - **[many_args_10](#many_args_10)** - 
+ - **[ptr](#ptr)** - 
+ - **[ptr_mut](#ptr_mut)** -  # Safety
+ - **[ptr_ptr](#ptr_ptr)** - 
+ - **[ref_simple](#ref_simple)** - 
+ - **[ref_mut_simple](#ref_mut_simple)** - 
+ - **[ref_option](#ref_option)** - 
+ - **[ref_mut_option](#ref_mut_option)** - 
+ - **[tupled](#tupled)** - 
+ - **[complex_args_1](#complex_args_1)** - 
+ - **[complex_args_2](#complex_args_2)** - 
+ - **[callback](#callback)** - 
+ - **[generic_1a](#generic_1a)** - 
+ - **[generic_1b](#generic_1b)** - 
+ - **[generic_1c](#generic_1c)** - 
+ - **[generic_2](#generic_2)** - 
+ - **[generic_3](#generic_3)** - 
+ - **[generic_4](#generic_4)** - 
+ - **[array_1](#array_1)** - 
+ - **[documented](#documented)** -  This function has documentation.
+ - **[ambiguous_1](#ambiguous_1)** - 
+ - **[ambiguous_2](#ambiguous_2)** - 
+ - **[ambiguous_3](#ambiguous_3)** - 
+ - **[namespaced_type](#namespaced_type)** - 
+ - **[panics](#panics)** - 
+ - **[renamed](#renamed)** - 
+ - **[sleep](#sleep)** - 
+ - **[weird_1](#weird_1)** - 
+ - **[visibility](#visibility)** - 
+ - **[repr_transparent](#repr_transparent)** - 
+ - **[pattern_ascii_pointer_1](#pattern_ascii_pointer_1)** - 
+ - **[pattern_ascii_pointer_2](#pattern_ascii_pointer_2)** - 
+ - **[pattern_ascii_pointer_len](#pattern_ascii_pointer_len)** - 
+ - **[pattern_ascii_pointer_return_slice](#pattern_ascii_pointer_return_slice)** - 
+ - **[pattern_ffi_slice_1](#pattern_ffi_slice_1)** - 
+ - **[pattern_ffi_slice_2](#pattern_ffi_slice_2)** - 
+ - **[pattern_ffi_slice_3](#pattern_ffi_slice_3)** - 
+ - **[pattern_ffi_slice_4](#pattern_ffi_slice_4)** - 
+ - **[pattern_ffi_slice_5](#pattern_ffi_slice_5)** - 
+ - **[pattern_ffi_slice_6](#pattern_ffi_slice_6)** - 
+ - **[pattern_ffi_slice_delegate](#pattern_ffi_slice_delegate)** - 
+ - **[pattern_ffi_slice_delegate_huge](#pattern_ffi_slice_delegate_huge)** - 
+ - **[pattern_ffi_option_1](#pattern_ffi_option_1)** - 
+ - **[pattern_ffi_option_2](#pattern_ffi_option_2)** - 
+ - **[pattern_ffi_bool](#pattern_ffi_bool)** - 
+ - **[pattern_api_guard](#pattern_api_guard)** - 
+ - **[pattern_callback_1](#pattern_callback_1)** - 
+ - **[pattern_callback_2](#pattern_callback_2)** - 
+
+### Classes
+Methods operating on common state.
+ - **[SimpleService](#SimpleService)** -  Some struct we want to expose as a class.
+     - **[NewWith](#SimpleService.NewWith)** <sup>**ctor**</sup> -  The constructor must return a `Result<Self, Error>`.
+     - **[NewWithout](#SimpleService.NewWithout)** <sup>**ctor**</sup> - 
+     - **[NewWithString](#SimpleService.NewWithString)** <sup>**ctor**</sup> - 
+     - **[NewFailing](#SimpleService.NewFailing)** <sup>**ctor**</sup> - 
+     - **[MethodResult](#SimpleService.MethodResult)** -  Methods returning a Result<(), _> are the default and do not
+     - **[MethodValue](#SimpleService.MethodValue)** - 
+     - **[MethodVoid](#SimpleService.MethodVoid)** -  This method should be documented.
+     - **[MethodMutSelf](#SimpleService.MethodMutSelf)** - 
+     - **[MethodMutSelfVoid](#SimpleService.MethodMutSelfVoid)** -  Single line.
+     - **[MethodMutSelfRef](#SimpleService.MethodMutSelfRef)** - 
+     - **[MethodMutSelfRefSlice](#SimpleService.MethodMutSelfRefSlice)** - 
+     - **[MethodMutSelfRefSliceLimited](#SimpleService.MethodMutSelfRefSliceLimited)** - 
+     - **[MethodMutSelfFfiError](#SimpleService.MethodMutSelfFfiError)** - 
+     - **[MethodMutSelfNoError](#SimpleService.MethodMutSelfNoError)** - 
+     - **[ReturnSlice](#SimpleService.ReturnSlice)** -  Warning, you _must_ discard the returned slice object before calling into this service
+     - **[ReturnSliceMut](#SimpleService.ReturnSliceMut)** -  Warning, you _must_ discard the returned slice object before calling into this service
+     - **[ReturnString](#SimpleService.ReturnString)** -  This function has no panic safeguards. If it panics your host app will be in an undefined state.
+     - **[MethodVoidFfiError](#SimpleService.MethodVoidFfiError)** - 
+     - **[MethodCallback](#SimpleService.MethodCallback)** - 
+ - **[SimpleServiceLifetime](#SimpleServiceLifetime)** - 
+     - **[NewWith](#SimpleServiceLifetime.NewWith)** <sup>**ctor**</sup> - 
+     - **[MethodLt](#SimpleServiceLifetime.MethodLt)** - 
+     - **[MethodLt2](#SimpleServiceLifetime.MethodLt2)** - 
+     - **[ReturnStringAcceptSlice](#SimpleServiceLifetime.ReturnStringAcceptSlice)** - 
+     - **[MethodVoidFfiError](#SimpleServiceLifetime.MethodVoidFfiError)** - 
+
+### Enums
+Groups of related constants.
+ - **[EnumDocumented](#EnumDocumented)** -  Documented enum.
+ - **[EnumRenamed](#EnumRenamed)** - 
+
+### Data Structs
+Composite data used by functions and methods.
+ - **[Array](#Array)** - 
+ - **[ExtraTypef32](#ExtraTypef32)** - 
+ - **[Genericu32](#Genericu32)** - 
+ - **[Genericu8](#Genericu8)** - 
+ - **[Inner](#Inner)** - 
+ - **[Phantomu8](#Phantomu8)** - 
+ - **[SomeForeignType](#SomeForeignType)** - 
+ - **[StructDocumented](#StructDocumented)** -  Documented struct.
+ - **[StructRenamed](#StructRenamed)** - 
+ - **[Tupled](#Tupled)** - 
+ - **[UseAsciiStringPattern](#UseAsciiStringPattern)** - 
+ - **[Vec](#Vec)** - 
+ - **[Vec1](#Vec1)** - 
+ - **[Vec2](#Vec2)** - 
+ - **[Vec3f32](#Vec3f32)** - 
+ - **[Visibility1](#Visibility1)** - 
+ - **[Visibility2](#Visibility2)** - 
+ - **[Weird1u32](#Weird1u32)** - 
+ - **[Weird2u8](#Weird2u8)** - 
+ - **[SliceBool](#SliceBool)** - A pointer and length of un-owned elements.
+ - **[SliceUseAsciiStringPattern](#SliceUseAsciiStringPattern)** - A pointer and length of un-owned elements.
+ - **[SliceVec3f32](#SliceVec3f32)** - A pointer and length of un-owned elements.
+ - **[Sliceu32](#Sliceu32)** - A pointer and length of un-owned elements.
+ - **[Sliceu8](#Sliceu8)** - A pointer and length of un-owned elements.
+ - **[OptionInner](#OptionInner)** - A boolean flag and optionally data.
+
+---
+
+# Types 
+
+
+ ### <a name="Array">**Array**</a>
+
+
+#### Fields 
+- **data** -  
+#### Definition 
+```csharp
+public partial struct Array
+{
+    public byte data0;
+    public byte data1;
+    public byte data2;
+    public byte data3;
+    public byte data4;
+    public byte data5;
+    public byte data6;
+    public byte data7;
+    public byte data8;
+    public byte data9;
+    public byte data10;
+    public byte data11;
+    public byte data12;
+    public byte data13;
+    public byte data14;
+    public byte data15;
+}
+```
+
+---
+
+
+
+ ### <a name="ExtraTypef32">**ExtraTypef32**</a>
+
+
+#### Fields 
+- **x** -  
+#### Definition 
+```csharp
+public partial struct ExtraTypef32
+{
+    public float x;
+}
+```
+
+---
+
+
+
+ ### <a name="Genericu32">**Genericu32**</a>
+
+
+#### Fields 
+- **x** -  
+#### Definition 
+```csharp
+public partial struct Genericu32
+{
+    public IntPtr x;
+}
+```
+
+---
+
+
+
+ ### <a name="Genericu8">**Genericu8**</a>
+
+
+#### Fields 
+- **x** -  
+#### Definition 
+```csharp
+public partial struct Genericu8
+{
+    public IntPtr x;
+}
+```
+
+---
+
+
+
+ ### <a name="Inner">**Inner**</a>
+
+
+#### Fields 
+- **x** -  
+#### Definition 
+```csharp
+public partial struct Inner
+{
+    float x;
+}
+```
+
+---
+
+
+
+ ### <a name="Phantomu8">**Phantomu8**</a>
+
+
+#### Fields 
+- **x** -  
+#### Definition 
+```csharp
+public partial struct Phantomu8
+{
+    public uint x;
+}
+```
+
+---
+
+
+
+ ### <a name="SomeForeignType">**SomeForeignType**</a>
+
+
+#### Fields 
+- **x** -  
+#### Definition 
+```csharp
+public partial struct SomeForeignType
+{
+    public uint x;
+}
+```
+
+---
+
+
+
+ ### <a name="StructDocumented">**StructDocumented**</a>
+
+Documented struct.
+
+#### Fields 
+- **x** -  Documented field. 
+#### Definition 
+```csharp
+public partial struct StructDocumented
+{
+    public float x;
+}
+```
+
+---
+
+
+
+ ### <a name="StructRenamed">**StructRenamed**</a>
+
+
+#### Fields 
+- **e** -  
+#### Definition 
+```csharp
+public partial struct StructRenamed
+{
+    public EnumRenamed e;
+}
+```
+
+---
+
+
+
+ ### <a name="Tupled">**Tupled**</a>
+
+
+#### Fields 
+- **x0** -  
+#### Definition 
+```csharp
+public partial struct Tupled
+{
+    public byte x0;
+}
+```
+
+---
+
+
+
+ ### <a name="UseAsciiStringPattern">**UseAsciiStringPattern**</a>
+
+
+#### Fields 
+- **ascii_string** -  
+#### Definition 
+```csharp
+public partial struct UseAsciiStringPattern
+{
+    public string ascii_string;
+}
+```
+
+---
+
+
+
+ ### <a name="Vec">**Vec**</a>
+
+
+#### Fields 
+- **x** -  
+- **z** -  
+#### Definition 
+```csharp
+public partial struct Vec
+{
+    public double x;
+    public double z;
+}
+```
+
+---
+
+
+
+ ### <a name="Vec1">**Vec1**</a>
+
+
+#### Fields 
+- **x** -  
+- **y** -  
+#### Definition 
+```csharp
+public partial struct Vec1
+{
+    public float x;
+    public float y;
+}
+```
+
+---
+
+
+
+ ### <a name="Vec2">**Vec2**</a>
+
+
+#### Fields 
+- **x** -  
+- **z** -  
+#### Definition 
+```csharp
+public partial struct Vec2
+{
+    public double x;
+    public double z;
+}
+```
+
+---
+
+
+
+ ### <a name="Vec3f32">**Vec3f32**</a>
+
+
+#### Fields 
+- **x** -  
+- **y** -  
+- **z** -  
+#### Definition 
+```csharp
+public partial struct Vec3f32
+{
+    public float x;
+    public float y;
+    public float z;
+}
+```
+
+---
+
+
+
+ ### <a name="Visibility1">**Visibility1**</a>
+
+
+#### Fields 
+- **pblc** -  
+- **prvt** -  
+#### Definition 
+```csharp
+public partial struct Visibility1
+{
+    public byte pblc;
+    byte prvt;
+}
+```
+
+---
+
+
+
+ ### <a name="Visibility2">**Visibility2**</a>
+
+
+#### Fields 
+- **pblc1** -  
+- **pblc2** -  
+#### Definition 
+```csharp
+public partial struct Visibility2
+{
+    public byte pblc1;
+    public byte pblc2;
+}
+```
+
+---
+
+
+
+ ### <a name="Weird1u32">**Weird1u32**</a>
+
+
+#### Fields 
+- **x** -  
+#### Definition 
+```csharp
+public partial struct Weird1u32
+{
+    uint x;
+}
+```
+
+---
+
+
+
+ ### <a name="Weird2u8">**Weird2u8**</a>
+
+
+#### Fields 
+- **t** -  
+- **a** -  
+- **r** -  
+#### Definition 
+```csharp
+public partial struct Weird2u8
+{
+    byte t;
+    byte a0;
+    byte a1;
+    byte a2;
+    byte a3;
+    byte a4;
+    IntPtr r;
+}
+```
+
+---
+
+
+
+ ### <a name="SliceBool">**SliceBool**</a>
+
+A pointer to an array of data someone else owns which may not be modified.
+
+#### Fields 
+- **data** - Pointer to start of immutable data. 
+- **len** - Number of elements. 
+#### Definition 
+```csharp
+public partial struct SliceBool
+{
+    IntPtr data;
+    ulong len;
+}
+```
+
+---
+
+
+
+ ### <a name="SliceUseAsciiStringPattern">**SliceUseAsciiStringPattern**</a>
+
+A pointer to an array of data someone else owns which may not be modified.
+
+#### Fields 
+- **data** - Pointer to start of immutable data. 
+- **len** - Number of elements. 
+#### Definition 
+```csharp
+public partial struct SliceUseAsciiStringPattern
+{
+    IntPtr data;
+    ulong len;
+}
+```
+
+---
+
+
+
+ ### <a name="SliceVec3f32">**SliceVec3f32**</a>
+
+A pointer to an array of data someone else owns which may not be modified.
+
+#### Fields 
+- **data** - Pointer to start of immutable data. 
+- **len** - Number of elements. 
+#### Definition 
+```csharp
+public partial struct SliceVec3f32
+{
+    IntPtr data;
+    ulong len;
+}
+```
+
+---
+
+
+
+ ### <a name="Sliceu32">**Sliceu32**</a>
+
+A pointer to an array of data someone else owns which may not be modified.
+
+#### Fields 
+- **data** - Pointer to start of immutable data. 
+- **len** - Number of elements. 
+#### Definition 
+```csharp
+public partial struct Sliceu32
+{
+    IntPtr data;
+    ulong len;
+}
+```
+
+---
+
+
+
+ ### <a name="Sliceu8">**Sliceu8**</a>
+
+A pointer to an array of data someone else owns which may not be modified.
+
+#### Fields 
+- **data** - Pointer to start of immutable data. 
+- **len** - Number of elements. 
+#### Definition 
+```csharp
+public partial struct Sliceu8
+{
+    IntPtr data;
+    ulong len;
+}
+```
+
+---
+
+
+
+ ### <a name="OptionInner">**OptionInner**</a>
+
+Option type containing boolean flag and maybe valid data.
+
+#### Fields 
+- **t** - Element that is maybe valid. 
+- **is_some** - Byte where `1` means element `t` is valid. 
+#### Definition 
+```csharp
+public partial struct OptionInner
+{
+    Inner t;
+    byte is_some;
+}
+```
+
+---
+
+# Enums 
+
+
+ ### <a name="EnumDocumented">**EnumDocumented**</a>
+
+Documented enum.
+
+#### Variants 
+- **A** -  Variant A. 
+- **B** -  Variant B. 
+- **C** -  Variant B. 
+#### Definition 
+```csharp
+public enum EnumDocumented
+{
+    A = 0,
+    B = 1,
+    C = 2,
+}
+```
+
+---
+
+
+
+ ### <a name="EnumRenamed">**EnumRenamed**</a>
+
+
+#### Variants 
+- **X** -  
+#### Definition 
+```csharp
+public enum EnumRenamed
+{
+    X = 0,
+}
+```
+
+---
+
+# Functions
+### <a name="primitive_void">**primitive_void**</a>
+#### Definition 
+```csharp
+public static extern void primitive_void();
+```
+
+---
+
+### <a name="primitive_void2">**primitive_void2**</a>
+#### Definition 
+```csharp
+public static extern void primitive_void2();
+```
+
+---
+
+### <a name="primitive_bool">**primitive_bool**</a>
+#### Definition 
+```csharp
+public static extern bool primitive_bool(bool x);
+```
+
+---
+
+### <a name="primitive_u8">**primitive_u8**</a>
+#### Definition 
+```csharp
+public static extern byte primitive_u8(byte x);
+```
+
+---
+
+### <a name="primitive_u16">**primitive_u16**</a>
+#### Definition 
+```csharp
+public static extern ushort primitive_u16(ushort x);
+```
+
+---
+
+### <a name="primitive_u32">**primitive_u32**</a>
+#### Definition 
+```csharp
+public static extern uint primitive_u32(uint x);
+```
+
+---
+
+### <a name="primitive_u64">**primitive_u64**</a>
+#### Definition 
+```csharp
+public static extern ulong primitive_u64(ulong x);
+```
+
+---
+
+### <a name="primitive_i8">**primitive_i8**</a>
+#### Definition 
+```csharp
+public static extern sbyte primitive_i8(sbyte x);
+```
+
+---
+
+### <a name="primitive_i16">**primitive_i16**</a>
+#### Definition 
+```csharp
+public static extern short primitive_i16(short x);
+```
+
+---
+
+### <a name="primitive_i32">**primitive_i32**</a>
+#### Definition 
+```csharp
+public static extern int primitive_i32(int x);
+```
+
+---
+
+### <a name="primitive_i64">**primitive_i64**</a>
+#### Definition 
+```csharp
+public static extern long primitive_i64(long x);
+```
+
+---
+
+### <a name="many_args_5">**many_args_5**</a>
+#### Definition 
+```csharp
+public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
+```
+
+---
+
+### <a name="many_args_10">**many_args_10**</a>
+#### Definition 
+```csharp
+public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
+```
+
+---
+
+### <a name="ptr">**ptr**</a>
+#### Definition 
+```csharp
+public static extern IntPtr ptr(ref long x);
+```
+
+---
+
+### <a name="ptr_mut">**ptr_mut**</a>
+### Safety
+
+Parameter x must point to valid data.
+#### Definition 
+```csharp
+public static extern IntPtr ptr_mut(out long x);
+```
+
+---
+
+### <a name="ptr_ptr">**ptr_ptr**</a>
+#### Definition 
+```csharp
+public static extern IntPtr ptr_ptr(ref IntPtr x);
+```
+
+---
+
+### <a name="ref_simple">**ref_simple**</a>
+#### Definition 
+```csharp
+public static extern IntPtr ref_simple(ref long x);
+```
+
+---
+
+### <a name="ref_mut_simple">**ref_mut_simple**</a>
+#### Definition 
+```csharp
+public static extern IntPtr ref_mut_simple(out long x);
+```
+
+---
+
+### <a name="ref_option">**ref_option**</a>
+#### Definition 
+```csharp
+public static extern bool ref_option(ref long x);
+```
+
+---
+
+### <a name="ref_mut_option">**ref_mut_option**</a>
+#### Definition 
+```csharp
+public static extern bool ref_mut_option(out long x);
+```
+
+---
+
+### <a name="tupled">**tupled**</a>
+#### Definition 
+```csharp
+public static extern Tupled tupled(Tupled x);
+```
+
+---
+
+### <a name="complex_args_1">**complex_args_1**</a>
+#### Definition 
+```csharp
+public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
+```
+
+---
+
+### <a name="complex_args_2">**complex_args_2**</a>
+#### Definition 
+```csharp
+public static extern IntPtr complex_args_2(SomeForeignType cmplx);
+```
+
+---
+
+### <a name="callback">**callback**</a>
+#### Definition 
+```csharp
+public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
+```
+
+---
+
+### <a name="generic_1a">**generic_1a**</a>
+#### Definition 
+```csharp
+public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
+```
+
+---
+
+### <a name="generic_1b">**generic_1b**</a>
+#### Definition 
+```csharp
+public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
+```
+
+---
+
+### <a name="generic_1c">**generic_1c**</a>
+#### Definition 
+```csharp
+public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
+```
+
+---
+
+### <a name="generic_2">**generic_2**</a>
+#### Definition 
+```csharp
+public static extern byte generic_2(IntPtr x);
+```
+
+---
+
+### <a name="generic_3">**generic_3**</a>
+#### Definition 
+```csharp
+public static extern byte generic_3(IntPtr x);
+```
+
+---
+
+### <a name="generic_4">**generic_4**</a>
+#### Definition 
+```csharp
+public static extern byte generic_4(IntPtr x);
+```
+
+---
+
+### <a name="array_1">**array_1**</a>
+#### Definition 
+```csharp
+public static extern byte array_1(Array x);
+```
+
+---
+
+### <a name="documented">**documented**</a>
+This function has documentation.
+#### Definition 
+```csharp
+public static extern EnumDocumented documented(StructDocumented x);
+```
+
+---
+
+### <a name="ambiguous_1">**ambiguous_1**</a>
+#### Definition 
+```csharp
+public static extern Vec1 ambiguous_1(Vec1 x);
+```
+
+---
+
+### <a name="ambiguous_2">**ambiguous_2**</a>
+#### Definition 
+```csharp
+public static extern Vec2 ambiguous_2(Vec2 x);
+```
+
+---
+
+### <a name="ambiguous_3">**ambiguous_3**</a>
+#### Definition 
+```csharp
+public static extern bool ambiguous_3(Vec1 x, Vec2 y);
+```
+
+---
+
+### <a name="namespaced_type">**namespaced_type**</a>
+#### Definition 
+```csharp
+public static extern Vec namespaced_type(Vec x);
+```
+
+---
+
+### <a name="panics">**panics**</a>
+#### Definition 
+```csharp
+public static extern FFIError panics();
+```
+
+---
+
+### <a name="renamed">**renamed**</a>
+#### Definition 
+```csharp
+public static extern EnumRenamed renamed(StructRenamed x);
+```
+
+---
+
+### <a name="sleep">**sleep**</a>
+#### Definition 
+```csharp
+public static extern void sleep(ulong millis);
+```
+
+---
+
+### <a name="weird_1">**weird_1**</a>
+#### Definition 
+```csharp
+public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
+```
+
+---
+
+### <a name="visibility">**visibility**</a>
+#### Definition 
+```csharp
+public static extern void visibility(Visibility1 x, Visibility2 y);
+```
+
+---
+
+### <a name="repr_transparent">**repr_transparent**</a>
+#### Definition 
+```csharp
+public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
+```
+
+---
+
+### <a name="pattern_ascii_pointer_1">**pattern_ascii_pointer_1**</a>
+#### Definition 
+```csharp
+public static extern uint pattern_ascii_pointer_1(string x);
+```
+
+---
+
+### <a name="pattern_ascii_pointer_2">**pattern_ascii_pointer_2**</a>
+#### Definition 
+```csharp
+public static extern IntPtr pattern_ascii_pointer_2();
+```
+
+---
+
+### <a name="pattern_ascii_pointer_len">**pattern_ascii_pointer_len**</a>
+#### Definition 
+```csharp
+public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
+```
+
+---
+
+### <a name="pattern_ascii_pointer_return_slice">**pattern_ascii_pointer_return_slice**</a>
+#### Definition 
+```csharp
+public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+```
+
+---
+
+### <a name="pattern_ffi_slice_1">**pattern_ffi_slice_1**</a>
+#### Definition 
+```csharp
+public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
+```
+
+---
+
+### <a name="pattern_ffi_slice_2">**pattern_ffi_slice_2**</a>
+#### Definition 
+```csharp
+public static extern Vec3f32 pattern_ffi_slice_2(SliceVec3f32 ffi_slice, int i);
+```
+
+---
+
+### <a name="pattern_ffi_slice_3">**pattern_ffi_slice_3**</a>
+#### Definition 
+```csharp
+public static extern void pattern_ffi_slice_3(SliceMutu8 slice, CallbackSliceMut callback);
+```
+
+---
+
+### <a name="pattern_ffi_slice_4">**pattern_ffi_slice_4**</a>
+#### Definition 
+```csharp
+public static extern void pattern_ffi_slice_4(Sliceu8 slice, SliceMutu8 slice2);
+```
+
+---
+
+### <a name="pattern_ffi_slice_5">**pattern_ffi_slice_5**</a>
+#### Definition 
+```csharp
+public static extern void pattern_ffi_slice_5(ref Sliceu8 slice, ref SliceMutu8 slice2);
+```
+
+---
+
+### <a name="pattern_ffi_slice_6">**pattern_ffi_slice_6**</a>
+#### Definition 
+```csharp
+public static extern void pattern_ffi_slice_6(ref SliceMutu8 slice, CallbackU8 callback);
+```
+
+---
+
+### <a name="pattern_ffi_slice_delegate">**pattern_ffi_slice_delegate**</a>
+#### Definition 
+```csharp
+public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
+```
+
+---
+
+### <a name="pattern_ffi_slice_delegate_huge">**pattern_ffi_slice_delegate_huge**</a>
+#### Definition 
+```csharp
+public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
+```
+
+---
+
+### <a name="pattern_ffi_option_1">**pattern_ffi_option_1**</a>
+#### Definition 
+```csharp
+public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
+```
+
+---
+
+### <a name="pattern_ffi_option_2">**pattern_ffi_option_2**</a>
+#### Definition 
+```csharp
+public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
+```
+
+---
+
+### <a name="pattern_ffi_bool">**pattern_ffi_bool**</a>
+#### Definition 
+```csharp
+public static extern Bool pattern_ffi_bool(Bool ffi_bool);
+```
+
+---
+
+### <a name="pattern_api_guard">**pattern_api_guard**</a>
+#### Definition 
+```csharp
+public static extern ulong pattern_api_guard();
+```
+
+---
+
+### <a name="pattern_callback_1">**pattern_callback_1**</a>
+#### Definition 
+```csharp
+public static extern uint pattern_callback_1(MyCallback callback, uint x);
+```
+
+---
+
+### <a name="pattern_callback_2">**pattern_callback_2**</a>
+#### Definition 
+```csharp
+public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
+```
+
+---
+
+# Classes
+## <a name="SimpleService">**SimpleService**</a>
+ Some struct we want to expose as a class.
+### <a name="SimpleService.NewWith">**SimpleService.NewWith**</a> <sup>ctor</sup>
+ The constructor must return a `Result<Self, Error>`.
+
+#### Definition 
+```csharp
+public SimpleService NewWith(uint some_value)
+```
+
+---
+
+### <a name="SimpleService.NewWithout">**SimpleService.NewWithout**</a> <sup>ctor</sup>
+
+#### Definition 
+```csharp
+public SimpleService NewWithout()
+```
+
+---
+
+### <a name="SimpleService.NewWithString">**SimpleService.NewWithString**</a> <sup>ctor</sup>
+
+#### Definition 
+```csharp
+public SimpleService NewWithString(string ascii)
+```
+
+---
+
+### <a name="SimpleService.NewFailing">**SimpleService.NewFailing**</a> <sup>ctor</sup>
+
+#### Definition 
+```csharp
+public SimpleService NewFailing(byte some_value)
+```
+
+---
+
+### <a name="SimpleService.MethodResult">**SimpleService.MethodResult**</a>
+ Methods returning a Result<(), _> are the default and do not
+ need annotations.
+
+#### Definition 
+```csharp
+public void MethodResult(uint anon1)
+```
+
+---
+
+### <a name="SimpleService.MethodValue">**SimpleService.MethodValue**</a>
+
+#### Definition 
+```csharp
+public uint MethodValue(uint x)
+```
+
+---
+
+### <a name="SimpleService.MethodVoid">**SimpleService.MethodVoid**</a>
+ This method should be documented.
+
+ Multiple lines.
+
+#### Definition 
+```csharp
+public void MethodVoid()
+```
+
+---
+
+### <a name="SimpleService.MethodMutSelf">**SimpleService.MethodMutSelf**</a>
+
+#### Definition 
+```csharp
+public byte MethodMutSelf(Sliceu8 slice)
+```
+
+---
+
+### <a name="SimpleService.MethodMutSelfVoid">**SimpleService.MethodMutSelfVoid**</a>
+ Single line.
+
+#### Definition 
+```csharp
+public void MethodMutSelfVoid(SliceBool slice)
+```
+
+---
+
+### <a name="SimpleService.MethodMutSelfRef">**SimpleService.MethodMutSelfRef**</a>
+
+#### Definition 
+```csharp
+public byte MethodMutSelfRef(ref byte x, out byte y)
+```
+
+---
+
+### <a name="SimpleService.MethodMutSelfRefSlice">**SimpleService.MethodMutSelfRefSlice**</a>
+
+#### Definition 
+```csharp
+public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+```
+
+---
+
+### <a name="SimpleService.MethodMutSelfRefSliceLimited">**SimpleService.MethodMutSelfRefSliceLimited**</a>
+
+#### Definition 
+```csharp
+public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+```
+
+---
+
+### <a name="SimpleService.MethodMutSelfFfiError">**SimpleService.MethodMutSelfFfiError**</a>
+
+#### Definition 
+```csharp
+public void MethodMutSelfFfiError(SliceMutu8 slice)
+```
+
+---
+
+### <a name="SimpleService.MethodMutSelfNoError">**SimpleService.MethodMutSelfNoError**</a>
+
+#### Definition 
+```csharp
+public void MethodMutSelfNoError(SliceMutu8 slice)
+```
+
+---
+
+### <a name="SimpleService.ReturnSlice">**SimpleService.ReturnSlice**</a>
+ Warning, you _must_ discard the returned slice object before calling into this service
+ again, as otherwise undefined behavior might happen.
+
+#### Definition 
+```csharp
+public Sliceu32 ReturnSlice()
+```
+
+---
+
+### <a name="SimpleService.ReturnSliceMut">**SimpleService.ReturnSliceMut**</a>
+ Warning, you _must_ discard the returned slice object before calling into this service
+ again, as otherwise undefined behavior might happen.
+
+#### Definition 
+```csharp
+public SliceMutu32 ReturnSliceMut()
+```
+
+---
+
+### <a name="SimpleService.ReturnString">**SimpleService.ReturnString**</a>
+ This function has no panic safeguards. If it panics your host app will be in an undefined state.
+
+#### Definition 
+```csharp
+public string ReturnString()
+```
+
+---
+
+### <a name="SimpleService.MethodVoidFfiError">**SimpleService.MethodVoidFfiError**</a>
+
+#### Definition 
+```csharp
+public void MethodVoidFfiError()
+```
+
+---
+
+### <a name="SimpleService.MethodCallback">**SimpleService.MethodCallback**</a>
+
+#### Definition 
+```csharp
+public void MethodCallback(MyCallback callback)
+```
+
+---
+
+
+
+## <a name="SimpleServiceLifetime">**SimpleServiceLifetime**</a>
+### <a name="SimpleServiceLifetime.NewWith">**SimpleServiceLifetime.NewWith**</a> <sup>ctor</sup>
+
+#### Definition 
+```csharp
+public SimpleServiceLifetime NewWith(ref uint some_value)
+```
+
+---
+
+### <a name="SimpleServiceLifetime.MethodLt">**SimpleServiceLifetime.MethodLt**</a>
+
+#### Definition 
+```csharp
+public void MethodLt(SliceBool slice)
+```
+
+---
+
+### <a name="SimpleServiceLifetime.MethodLt2">**SimpleServiceLifetime.MethodLt2**</a>
+
+#### Definition 
+```csharp
+public void MethodLt2(SliceBool slice)
+```
+
+---
+
+### <a name="SimpleServiceLifetime.ReturnStringAcceptSlice">**SimpleServiceLifetime.ReturnStringAcceptSlice**</a>
+
+#### Definition 
+```csharp
+public string ReturnStringAcceptSlice(Sliceu8 anon1)
+```
+
+---
+
+### <a name="SimpleServiceLifetime.MethodVoidFfiError">**SimpleServiceLifetime.MethodVoidFfiError**</a>
+
+#### Definition 
+```csharp
+public void MethodVoidFfiError()
+```
+
+---
+
+
+
+

--- a/backends/csharp/tests/output_safe/Interop.cs
+++ b/backends/csharp/tests/output_safe/Interop.cs
@@ -34,58 +34,44 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void")]
         public static extern void primitive_void();
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void2")]
         public static extern void primitive_void2();
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_bool")]
         public static extern bool primitive_bool(bool x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u8")]
         public static extern byte primitive_u8(byte x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u16")]
         public static extern ushort primitive_u16(ushort x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u32")]
         public static extern uint primitive_u32(uint x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u64")]
         public static extern ulong primitive_u64(ulong x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i8")]
         public static extern sbyte primitive_i8(sbyte x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i16")]
         public static extern short primitive_i16(short x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i32")]
         public static extern int primitive_i32(int x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i64")]
         public static extern long primitive_i64(long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_5")]
         public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_10")]
         public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr")]
         public static extern IntPtr ptr(ref long x);
-
 
         /// # Safety
         ///
@@ -93,30 +79,23 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
         public static extern IntPtr ptr_mut(out long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_simple")]
         public static extern IntPtr ref_simple(ref long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
         public static extern IntPtr ref_mut_simple(out long x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
         public static extern bool ref_mut_option(out long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_1")]
         public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
@@ -132,59 +111,45 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_2")]
         public static extern IntPtr complex_args_2(SomeForeignType cmplx);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1a")]
         public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1b")]
         public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1c")]
         public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_2")]
         public static extern byte generic_2(IntPtr x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_3")]
         public static extern byte generic_3(IntPtr x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_4")]
         public static extern byte generic_4(IntPtr x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "array_1")]
         public static extern byte array_1(Array x);
-
 
         /// This function has documentation.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "documented")]
         public static extern EnumDocumented documented(StructDocumented x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_1")]
         public static extern Vec1 ambiguous_1(Vec1 x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_2")]
         public static extern Vec2 ambiguous_2(Vec2 x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_3")]
         public static extern bool ambiguous_3(Vec1 x, Vec2 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespaced_type")]
         public static extern Vec namespaced_type(Vec x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "panics")]
         public static extern FFIError panics();
@@ -200,38 +165,29 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed")]
         public static extern EnumRenamed renamed(StructRenamed x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "sleep")]
         public static extern void sleep(ulong millis);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "weird_1")]
         public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "visibility")]
         public static extern void visibility(Visibility1 x, Visibility2 y);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "repr_transparent")]
         public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_1")]
         public static extern uint pattern_ascii_pointer_1(string x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_2")]
         public static extern IntPtr pattern_ascii_pointer_2();
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_len")]
         public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
@@ -338,34 +294,26 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_1")]
         public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_2")]
         public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_bool")]
         public static extern Bool pattern_ffi_bool(Bool ffi_bool);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_api_guard")]
         public static extern ulong pattern_api_guard();
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(MyCallback callback, uint x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
-
 
         /// Destroys the given instance.
         ///
@@ -454,13 +402,11 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_value")]
         public static extern uint simple_service_method_value(IntPtr context, uint x);
 
-
         /// This method should be documented.
         ///
         /// Multiple lines.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void")]
         public static extern void simple_service_method_void(IntPtr context);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self")]
         public static extern byte simple_service_method_mut_self(IntPtr context, Sliceu8 slice);
@@ -498,7 +444,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
         public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
         public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
@@ -580,17 +525,14 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice")]
         public static extern Sliceu32 simple_service_return_slice(IntPtr context);
 
-
         /// Warning, you _must_ discard the returned slice object before calling into this service
         /// again, as otherwise undefined behavior might happen.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice_mut")]
         public static extern SliceMutu32 simple_service_return_slice_mut(IntPtr context);
 
-
         /// This function has no panic safeguards. If it panics your host app will be in an undefined state.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_string")]
         public static extern IntPtr simple_service_return_string(IntPtr context);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void_ffi_error")]
         public static extern FFIError simple_service_method_void_ffi_error(IntPtr context);

--- a/backends/csharp/tests/output_safe/Interop.cs.expected
+++ b/backends/csharp/tests/output_safe/Interop.cs.expected
@@ -34,58 +34,44 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void")]
         public static extern void primitive_void();
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void2")]
         public static extern void primitive_void2();
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_bool")]
         public static extern bool primitive_bool(bool x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u8")]
         public static extern byte primitive_u8(byte x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u16")]
         public static extern ushort primitive_u16(ushort x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u32")]
         public static extern uint primitive_u32(uint x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u64")]
         public static extern ulong primitive_u64(ulong x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i8")]
         public static extern sbyte primitive_i8(sbyte x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i16")]
         public static extern short primitive_i16(short x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i32")]
         public static extern int primitive_i32(int x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i64")]
         public static extern long primitive_i64(long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_5")]
         public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_10")]
         public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr")]
         public static extern IntPtr ptr(ref long x);
-
 
         /// # Safety
         ///
@@ -93,30 +79,23 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
         public static extern IntPtr ptr_mut(out long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_simple")]
         public static extern IntPtr ref_simple(ref long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
         public static extern IntPtr ref_mut_simple(out long x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
         public static extern bool ref_mut_option(out long x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_1")]
         public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
@@ -132,59 +111,45 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_2")]
         public static extern IntPtr complex_args_2(SomeForeignType cmplx);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1a")]
         public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1b")]
         public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1c")]
         public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_2")]
         public static extern byte generic_2(IntPtr x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_3")]
         public static extern byte generic_3(IntPtr x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_4")]
         public static extern byte generic_4(IntPtr x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "array_1")]
         public static extern byte array_1(Array x);
-
 
         /// This function has documentation.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "documented")]
         public static extern EnumDocumented documented(StructDocumented x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_1")]
         public static extern Vec1 ambiguous_1(Vec1 x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_2")]
         public static extern Vec2 ambiguous_2(Vec2 x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_3")]
         public static extern bool ambiguous_3(Vec1 x, Vec2 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespaced_type")]
         public static extern Vec namespaced_type(Vec x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "panics")]
         public static extern FFIError panics();
@@ -200,38 +165,29 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed")]
         public static extern EnumRenamed renamed(StructRenamed x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "sleep")]
         public static extern void sleep(ulong millis);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "weird_1")]
         public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "visibility")]
         public static extern void visibility(Visibility1 x, Visibility2 y);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "repr_transparent")]
         public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_1")]
         public static extern uint pattern_ascii_pointer_1(string x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_2")]
         public static extern IntPtr pattern_ascii_pointer_2();
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_len")]
         public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
@@ -338,34 +294,26 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_1")]
         public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_2")]
         public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_bool")]
         public static extern Bool pattern_ffi_bool(Bool ffi_bool);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_api_guard")]
         public static extern ulong pattern_api_guard();
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(MyCallback callback, uint x);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
-
 
         /// Destroys the given instance.
         ///
@@ -454,13 +402,11 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_value")]
         public static extern uint simple_service_method_value(IntPtr context, uint x);
 
-
         /// This method should be documented.
         ///
         /// Multiple lines.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void")]
         public static extern void simple_service_method_void(IntPtr context);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self")]
         public static extern byte simple_service_method_mut_self(IntPtr context, Sliceu8 slice);
@@ -498,7 +444,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
         public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
         public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
@@ -580,17 +525,14 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice")]
         public static extern Sliceu32 simple_service_return_slice(IntPtr context);
 
-
         /// Warning, you _must_ discard the returned slice object before calling into this service
         /// again, as otherwise undefined behavior might happen.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice_mut")]
         public static extern SliceMutu32 simple_service_return_slice_mut(IntPtr context);
 
-
         /// This function has no panic safeguards. If it panics your host app will be in an undefined state.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_string")]
         public static extern IntPtr simple_service_return_string(IntPtr context);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void_ffi_error")]
         public static extern FFIError simple_service_method_void_ffi_error(IntPtr context);

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs
@@ -39,72 +39,44 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void")]
         public static extern void primitive_void();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void2")]
         public static extern void primitive_void2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_bool")]
         public static extern bool primitive_bool(bool x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u8")]
         public static extern byte primitive_u8(byte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u16")]
         public static extern ushort primitive_u16(ushort x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u32")]
         public static extern uint primitive_u32(uint x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u64")]
         public static extern ulong primitive_u64(ulong x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i8")]
         public static extern sbyte primitive_i8(sbyte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i16")]
         public static extern short primitive_i16(short x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i32")]
         public static extern int primitive_i32(int x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i64")]
         public static extern long primitive_i64(long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_5")]
         public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_10")]
         public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr")]
         public static extern IntPtr ptr(ref long x);
-
-
 
         /// # Safety
         ///
@@ -112,37 +84,23 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
         public static extern IntPtr ptr_mut(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_simple")]
         public static extern IntPtr ref_simple(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
         public static extern IntPtr ref_mut_simple(out long x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
         public static extern bool ref_mut_option(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_1")]
         public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
@@ -155,15 +113,11 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_2")]
         public static extern IntPtr complex_args_2(SomeForeignType cmplx);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(IntPtr callback, byte value);
@@ -172,63 +126,39 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1a")]
         public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1b")]
         public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1c")]
         public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_2")]
         public static extern byte generic_2(IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_3")]
         public static extern byte generic_3(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_4")]
         public static extern byte generic_4(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "array_1")]
         public static extern byte array_1(Array x);
-
-
 
         /// This function has documentation.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "documented")]
         public static extern EnumDocumented documented(StructDocumented x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_1")]
         public static extern Vec1 ambiguous_1(Vec1 x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_2")]
         public static extern Vec2 ambiguous_2(Vec2 x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_3")]
         public static extern bool ambiguous_3(Vec1 x, Vec2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespaced_type")]
         public static extern Vec namespaced_type(Vec x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "panics")]
         public static extern FFIError panics();
@@ -241,51 +171,32 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed")]
         public static extern EnumRenamed renamed(StructRenamed x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "sleep")]
         public static extern void sleep(ulong millis);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "weird_1")]
         public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "visibility")]
         public static extern void visibility(Visibility1 x, Visibility2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "repr_transparent")]
         public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_1")]
         public static extern uint pattern_ascii_pointer_1(string x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_2")]
         public static extern IntPtr pattern_ascii_pointer_2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_len")]
         public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
@@ -432,14 +343,12 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(IntPtr callback);
 
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(IntPtr callback);
@@ -448,26 +357,17 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_1")]
         public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_2")]
         public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_bool")]
         public static extern Bool pattern_ffi_bool(Bool ffi_bool);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_api_guard")]
         public static extern ulong pattern_api_guard();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(MyCallback callback, uint x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(IntPtr callback, uint x);
@@ -475,7 +375,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(IntPtr callback);
@@ -504,7 +403,6 @@ namespace My.Company
             }
         }
 
-
         /// The constructor must return a `Result<Self, Error>`.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with")]
         public static extern FFIError simple_service_new_with(ref IntPtr context, uint some_value);
@@ -518,7 +416,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_without")]
         public static extern FFIError simple_service_new_without(ref IntPtr context);
 
@@ -529,7 +426,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with_string")]
         public static extern FFIError simple_service_new_with_string(ref IntPtr context, string ascii);
@@ -542,7 +438,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_failing")]
         public static extern FFIError simple_service_new_failing(ref IntPtr context, byte some_value);
 
@@ -553,7 +448,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         /// Methods returning a Result<(), _> are the default and do not
         /// need annotations.
@@ -570,19 +464,14 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_value")]
         public static extern uint simple_service_method_value(IntPtr context, uint x);
-
-
 
         /// This method should be documented.
         ///
         /// Multiple lines.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void")]
         public static extern void simple_service_method_void(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self")]
         public static extern byte simple_service_method_mut_self(IntPtr context, Sliceu8 slice);
@@ -631,8 +520,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
         public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
         public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
@@ -744,20 +631,14 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice")]
         public static extern Sliceu32 simple_service_return_slice(IntPtr context);
 
-
-
         /// Warning, you _must_ discard the returned slice object before calling into this service
         /// again, as otherwise undefined behavior might happen.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice_mut")]
         public static extern SliceMutu32 simple_service_return_slice_mut(IntPtr context);
 
-
-
         /// This function has no panic safeguards. If it panics your host app will be in an undefined state.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_string")]
         public static extern IntPtr simple_service_return_string(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void_ffi_error")]
         public static extern FFIError simple_service_method_void_ffi_error(IntPtr context);
@@ -769,7 +650,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_callback")]
         public static extern FFIError simple_service_method_callback(IntPtr context, MyCallback callback);
@@ -809,7 +689,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_new_with")]
         public static extern FFIError simple_service_lt_new_with(ref IntPtr context, ref uint some_value);
 
@@ -820,7 +699,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_method_lt")]
         public static extern void simple_service_lt_method_lt(IntPtr context, SliceBool slice);
@@ -897,7 +775,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
     }
 

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
@@ -39,72 +39,44 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void")]
         public static extern void primitive_void();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void2")]
         public static extern void primitive_void2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_bool")]
         public static extern bool primitive_bool(bool x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u8")]
         public static extern byte primitive_u8(byte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u16")]
         public static extern ushort primitive_u16(ushort x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u32")]
         public static extern uint primitive_u32(uint x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u64")]
         public static extern ulong primitive_u64(ulong x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i8")]
         public static extern sbyte primitive_i8(sbyte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i16")]
         public static extern short primitive_i16(short x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i32")]
         public static extern int primitive_i32(int x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i64")]
         public static extern long primitive_i64(long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_5")]
         public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_10")]
         public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr")]
         public static extern IntPtr ptr(ref long x);
-
-
 
         /// # Safety
         ///
@@ -112,37 +84,23 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
         public static extern IntPtr ptr_mut(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_simple")]
         public static extern IntPtr ref_simple(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
         public static extern IntPtr ref_mut_simple(out long x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
         public static extern bool ref_mut_option(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_1")]
         public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
@@ -155,15 +113,11 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_2")]
         public static extern IntPtr complex_args_2(SomeForeignType cmplx);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(IntPtr callback, byte value);
@@ -172,63 +126,39 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1a")]
         public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1b")]
         public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1c")]
         public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_2")]
         public static extern byte generic_2(IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_3")]
         public static extern byte generic_3(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_4")]
         public static extern byte generic_4(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "array_1")]
         public static extern byte array_1(Array x);
-
-
 
         /// This function has documentation.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "documented")]
         public static extern EnumDocumented documented(StructDocumented x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_1")]
         public static extern Vec1 ambiguous_1(Vec1 x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_2")]
         public static extern Vec2 ambiguous_2(Vec2 x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_3")]
         public static extern bool ambiguous_3(Vec1 x, Vec2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespaced_type")]
         public static extern Vec namespaced_type(Vec x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "panics")]
         public static extern FFIError panics();
@@ -241,51 +171,32 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed")]
         public static extern EnumRenamed renamed(StructRenamed x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "sleep")]
         public static extern void sleep(ulong millis);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "weird_1")]
         public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "visibility")]
         public static extern void visibility(Visibility1 x, Visibility2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "repr_transparent")]
         public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_1")]
         public static extern uint pattern_ascii_pointer_1(string x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_2")]
         public static extern IntPtr pattern_ascii_pointer_2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_len")]
         public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
@@ -432,14 +343,12 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(IntPtr callback);
 
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(IntPtr callback);
@@ -448,26 +357,17 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_1")]
         public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_2")]
         public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_bool")]
         public static extern Bool pattern_ffi_bool(Bool ffi_bool);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_api_guard")]
         public static extern ulong pattern_api_guard();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(MyCallback callback, uint x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(IntPtr callback, uint x);
@@ -475,7 +375,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(IntPtr callback);
@@ -504,7 +403,6 @@ namespace My.Company
             }
         }
 
-
         /// The constructor must return a `Result<Self, Error>`.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with")]
         public static extern FFIError simple_service_new_with(ref IntPtr context, uint some_value);
@@ -518,7 +416,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_without")]
         public static extern FFIError simple_service_new_without(ref IntPtr context);
 
@@ -529,7 +426,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with_string")]
         public static extern FFIError simple_service_new_with_string(ref IntPtr context, string ascii);
@@ -542,7 +438,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_failing")]
         public static extern FFIError simple_service_new_failing(ref IntPtr context, byte some_value);
 
@@ -553,7 +448,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         /// Methods returning a Result<(), _> are the default and do not
         /// need annotations.
@@ -570,19 +464,14 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_value")]
         public static extern uint simple_service_method_value(IntPtr context, uint x);
-
-
 
         /// This method should be documented.
         ///
         /// Multiple lines.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void")]
         public static extern void simple_service_method_void(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self")]
         public static extern byte simple_service_method_mut_self(IntPtr context, Sliceu8 slice);
@@ -631,8 +520,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
         public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
         public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
@@ -744,20 +631,14 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice")]
         public static extern Sliceu32 simple_service_return_slice(IntPtr context);
 
-
-
         /// Warning, you _must_ discard the returned slice object before calling into this service
         /// again, as otherwise undefined behavior might happen.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice_mut")]
         public static extern SliceMutu32 simple_service_return_slice_mut(IntPtr context);
 
-
-
         /// This function has no panic safeguards. If it panics your host app will be in an undefined state.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_string")]
         public static extern IntPtr simple_service_return_string(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void_ffi_error")]
         public static extern FFIError simple_service_method_void_ffi_error(IntPtr context);
@@ -769,7 +650,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_callback")]
         public static extern FFIError simple_service_method_callback(IntPtr context, MyCallback callback);
@@ -809,7 +689,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_new_with")]
         public static extern FFIError simple_service_lt_new_with(ref IntPtr context, ref uint some_value);
 
@@ -820,7 +699,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_method_lt")]
         public static extern void simple_service_lt_method_lt(IntPtr context, SliceBool slice);
@@ -897,7 +775,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
     }
 

--- a/backends/csharp/tests/output_unsafe/Interop.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.cs
@@ -39,72 +39,44 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void")]
         public static extern void primitive_void();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void2")]
         public static extern void primitive_void2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_bool")]
         public static extern bool primitive_bool(bool x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u8")]
         public static extern byte primitive_u8(byte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u16")]
         public static extern ushort primitive_u16(ushort x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u32")]
         public static extern uint primitive_u32(uint x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u64")]
         public static extern ulong primitive_u64(ulong x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i8")]
         public static extern sbyte primitive_i8(sbyte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i16")]
         public static extern short primitive_i16(short x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i32")]
         public static extern int primitive_i32(int x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i64")]
         public static extern long primitive_i64(long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_5")]
         public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_10")]
         public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr")]
         public static extern IntPtr ptr(ref long x);
-
-
 
         /// # Safety
         ///
@@ -112,37 +84,23 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
         public static extern IntPtr ptr_mut(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_simple")]
         public static extern IntPtr ref_simple(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
         public static extern IntPtr ref_mut_simple(out long x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
         public static extern bool ref_mut_option(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_1")]
         public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
@@ -155,15 +113,11 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_2")]
         public static extern IntPtr complex_args_2(SomeForeignType cmplx);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(IntPtr callback, byte value);
@@ -172,63 +126,39 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1a")]
         public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1b")]
         public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1c")]
         public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_2")]
         public static extern byte generic_2(IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_3")]
         public static extern byte generic_3(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_4")]
         public static extern byte generic_4(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "array_1")]
         public static extern byte array_1(Array x);
-
-
 
         /// This function has documentation.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "documented")]
         public static extern EnumDocumented documented(StructDocumented x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_1")]
         public static extern Vec1 ambiguous_1(Vec1 x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_2")]
         public static extern Vec2 ambiguous_2(Vec2 x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_3")]
         public static extern bool ambiguous_3(Vec1 x, Vec2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespaced_type")]
         public static extern Vec namespaced_type(Vec x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "panics")]
         public static extern FFIError panics();
@@ -241,51 +171,32 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed")]
         public static extern EnumRenamed renamed(StructRenamed x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "sleep")]
         public static extern void sleep(ulong millis);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "weird_1")]
         public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "visibility")]
         public static extern void visibility(Visibility1 x, Visibility2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "repr_transparent")]
         public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_1")]
         public static extern uint pattern_ascii_pointer_1(string x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_2")]
         public static extern IntPtr pattern_ascii_pointer_2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_len")]
         public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
@@ -432,14 +343,12 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(IntPtr callback);
 
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(IntPtr callback);
@@ -448,26 +357,17 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_1")]
         public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_2")]
         public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_bool")]
         public static extern Bool pattern_ffi_bool(Bool ffi_bool);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_api_guard")]
         public static extern ulong pattern_api_guard();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(MyCallback callback, uint x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(IntPtr callback, uint x);
@@ -475,7 +375,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(IntPtr callback);
@@ -504,7 +403,6 @@ namespace My.Company
             }
         }
 
-
         /// The constructor must return a `Result<Self, Error>`.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with")]
         public static extern FFIError simple_service_new_with(ref IntPtr context, uint some_value);
@@ -518,7 +416,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_without")]
         public static extern FFIError simple_service_new_without(ref IntPtr context);
 
@@ -529,7 +426,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with_string")]
         public static extern FFIError simple_service_new_with_string(ref IntPtr context, string ascii);
@@ -542,7 +438,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_failing")]
         public static extern FFIError simple_service_new_failing(ref IntPtr context, byte some_value);
 
@@ -553,7 +448,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         /// Methods returning a Result<(), _> are the default and do not
         /// need annotations.
@@ -570,19 +464,14 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_value")]
         public static extern uint simple_service_method_value(IntPtr context, uint x);
-
-
 
         /// This method should be documented.
         ///
         /// Multiple lines.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void")]
         public static extern void simple_service_method_void(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self")]
         public static extern byte simple_service_method_mut_self(IntPtr context, Sliceu8 slice);
@@ -631,8 +520,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
         public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
         public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
@@ -744,20 +631,14 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice")]
         public static extern Sliceu32 simple_service_return_slice(IntPtr context);
 
-
-
         /// Warning, you _must_ discard the returned slice object before calling into this service
         /// again, as otherwise undefined behavior might happen.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice_mut")]
         public static extern SliceMutu32 simple_service_return_slice_mut(IntPtr context);
 
-
-
         /// This function has no panic safeguards. If it panics your host app will be in an undefined state.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_string")]
         public static extern IntPtr simple_service_return_string(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void_ffi_error")]
         public static extern FFIError simple_service_method_void_ffi_error(IntPtr context);
@@ -769,7 +650,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_callback")]
         public static extern FFIError simple_service_method_callback(IntPtr context, MyCallback callback);
@@ -809,7 +689,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_new_with")]
         public static extern FFIError simple_service_lt_new_with(ref IntPtr context, ref uint some_value);
 
@@ -820,7 +699,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_method_lt")]
         public static extern void simple_service_lt_method_lt(IntPtr context, SliceBool slice);
@@ -897,7 +775,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
     }
 

--- a/backends/csharp/tests/output_unsafe/Interop.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.cs.expected
@@ -39,72 +39,44 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void")]
         public static extern void primitive_void();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_void2")]
         public static extern void primitive_void2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_bool")]
         public static extern bool primitive_bool(bool x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u8")]
         public static extern byte primitive_u8(byte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u16")]
         public static extern ushort primitive_u16(ushort x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u32")]
         public static extern uint primitive_u32(uint x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_u64")]
         public static extern ulong primitive_u64(ulong x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i8")]
         public static extern sbyte primitive_i8(sbyte x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i16")]
         public static extern short primitive_i16(short x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i32")]
         public static extern int primitive_i32(int x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "primitive_i64")]
         public static extern long primitive_i64(long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_5")]
         public static extern long many_args_5(long x0, long x1, long x2, long x3, long x4);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "many_args_10")]
         public static extern long many_args_10(long x0, long x1, long x2, long x3, long x4, long x5, long x6, long x7, long x8, long x9);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr")]
         public static extern IntPtr ptr(ref long x);
-
-
 
         /// # Safety
         ///
@@ -112,37 +84,23 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
         public static extern IntPtr ptr_mut(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_simple")]
         public static extern IntPtr ref_simple(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
         public static extern IntPtr ref_mut_simple(out long x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
         public static extern bool ref_mut_option(out long x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_1")]
         public static extern FFIError complex_args_1(Vec3f32 a, ref Tupled b);
@@ -155,15 +113,11 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "complex_args_2")]
         public static extern IntPtr complex_args_2(SomeForeignType cmplx);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(InteropDelegate_fn_u8_rval_u8 callback, byte value);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "callback")]
         public static extern byte callback(IntPtr callback, byte value);
@@ -172,63 +126,39 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1a")]
         public static extern uint generic_1a(Genericu32 x, Phantomu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1b")]
         public static extern byte generic_1b(Genericu8 x, Phantomu8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_1c")]
         public static extern byte generic_1c(ref Genericu8 x, ref Genericu8 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_2")]
         public static extern byte generic_2(IntPtr x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_3")]
         public static extern byte generic_3(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "generic_4")]
         public static extern byte generic_4(IntPtr x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "array_1")]
         public static extern byte array_1(Array x);
-
-
 
         /// This function has documentation.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "documented")]
         public static extern EnumDocumented documented(StructDocumented x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_1")]
         public static extern Vec1 ambiguous_1(Vec1 x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_2")]
         public static extern Vec2 ambiguous_2(Vec2 x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ambiguous_3")]
         public static extern bool ambiguous_3(Vec1 x, Vec2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "namespaced_type")]
         public static extern Vec namespaced_type(Vec x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "panics")]
         public static extern FFIError panics();
@@ -241,51 +171,32 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "renamed")]
         public static extern EnumRenamed renamed(StructRenamed x);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "sleep")]
         public static extern void sleep(ulong millis);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "weird_1")]
         public static extern bool weird_1(Weird1u32 x, Weird2u8 y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "visibility")]
         public static extern void visibility(Visibility1 x, Visibility2 y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "repr_transparent")]
         public static extern Tupled repr_transparent(Tupled x, ref Tupled r);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_1")]
         public static extern uint pattern_ascii_pointer_1(string x);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_2")]
         public static extern IntPtr pattern_ascii_pointer_2();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_len")]
         public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPattern y);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);
@@ -432,14 +343,12 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(CallbackFFISlice callback);
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate")]
         public static extern byte pattern_ffi_slice_delegate(IntPtr callback);
 
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(CallbackHugeVecSlice callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_delegate_huge")]
         public static extern Vec3f32 pattern_ffi_slice_delegate_huge(IntPtr callback);
@@ -448,26 +357,17 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_1")]
         public static extern OptionInner pattern_ffi_option_1(OptionInner ffi_slice);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_option_2")]
         public static extern Inner pattern_ffi_option_2(OptionInner ffi_slice);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_bool")]
         public static extern Bool pattern_ffi_bool(Bool ffi_bool);
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_api_guard")]
         public static extern ulong pattern_api_guard();
 
-
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(MyCallback callback, uint x);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_1")]
         public static extern uint pattern_callback_1(IntPtr callback, uint x);
@@ -475,7 +375,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(MyCallbackVoid callback);
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_callback_2")]
         public static extern MyCallbackVoid pattern_callback_2(IntPtr callback);
@@ -504,7 +403,6 @@ namespace My.Company
             }
         }
 
-
         /// The constructor must return a `Result<Self, Error>`.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with")]
         public static extern FFIError simple_service_new_with(ref IntPtr context, uint some_value);
@@ -518,7 +416,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_without")]
         public static extern FFIError simple_service_new_without(ref IntPtr context);
 
@@ -529,7 +426,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_with_string")]
         public static extern FFIError simple_service_new_with_string(ref IntPtr context, string ascii);
@@ -542,7 +438,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_new_failing")]
         public static extern FFIError simple_service_new_failing(ref IntPtr context, byte some_value);
 
@@ -553,7 +448,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         /// Methods returning a Result<(), _> are the default and do not
         /// need annotations.
@@ -570,19 +464,14 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_value")]
         public static extern uint simple_service_method_value(IntPtr context, uint x);
-
-
 
         /// This method should be documented.
         ///
         /// Multiple lines.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void")]
         public static extern void simple_service_method_void(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self")]
         public static extern byte simple_service_method_mut_self(IntPtr context, Sliceu8 slice);
@@ -631,8 +520,6 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
         public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
         public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
@@ -744,20 +631,14 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice")]
         public static extern Sliceu32 simple_service_return_slice(IntPtr context);
 
-
-
         /// Warning, you _must_ discard the returned slice object before calling into this service
         /// again, as otherwise undefined behavior might happen.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_slice_mut")]
         public static extern SliceMutu32 simple_service_return_slice_mut(IntPtr context);
 
-
-
         /// This function has no panic safeguards. If it panics your host app will be in an undefined state.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_return_string")]
         public static extern IntPtr simple_service_return_string(IntPtr context);
-
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_void_ffi_error")]
         public static extern FFIError simple_service_method_void_ffi_error(IntPtr context);
@@ -769,7 +650,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_callback")]
         public static extern FFIError simple_service_method_callback(IntPtr context, MyCallback callback);
@@ -809,7 +689,6 @@ namespace My.Company
             }
         }
 
-
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_new_with")]
         public static extern FFIError simple_service_lt_new_with(ref IntPtr context, ref uint some_value);
 
@@ -820,7 +699,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_lt_method_lt")]
         public static extern void simple_service_lt_method_lt(IntPtr context, SliceBool slice);
@@ -897,7 +775,6 @@ namespace My.Company
                 throw new InteropException<FFIError>(rval);
             }
         }
-
 
     }
 

--- a/core/src/writer.rs
+++ b/core/src/writer.rs
@@ -5,6 +5,13 @@ use std::io::Write;
 /// You might not realize how hard it can be to type exactly 4 spaces.
 pub const FOUR_SPACES: &str = "    ";
 
+/// In some places we can write for docs or for actual code generation.
+#[derive(PartialOrd, PartialEq, Copy, Clone, Debug)]
+pub enum WriteFor {
+    Code,
+    Docs,
+}
+
 /// Convenience helper to allow backends to write code with indentation.
 pub struct IndentWriter<'a> {
     one_indent: String,


### PR DESCRIPTION
This change adds a C# documentation writer, similar to the one for the CPython backend. Also included is change to a utility function to convert Rust function names to C# function names.