### PR TITLE
Use name and parameter names in generated bindings for callback macro

### DIFF
--- a/backends/c/src/converter.rs
+++ b/backends/c/src/converter.rs
@@ -1,8 +1,10 @@
 use crate::config::ToNamingStyle;
 use crate::Config;
 use interoptopus::lang::c::{CType, CompositeType, Constant, ConstantValue, EnumType, FnPointerType, Function, OpaqueType, PrimitiveType, PrimitiveValue, Variant};
+use interoptopus::patterns::callbacks::NamedCallback;
 use interoptopus::patterns::TypePattern;
 use interoptopus::util::safe_name;
+use std::fmt::format;
 
 /// Implements [`CTypeConverter`].
 #[derive(Clone)]
@@ -30,6 +32,10 @@ pub trait CTypeConverter {
 
     /// Converts an Rust `fn()` to a C# delegate name such as `InteropDelegate`.
     fn fnpointer_to_typename(&self, x: &FnPointerType) -> String;
+
+    fn named_callback_to_typename(&self, x: &NamedCallback) -> String {
+        format!("{}{}", self.config().prefix, x.name().to_naming_style(&self.config().type_naming))
+    }
 
     /// Converts the `u32` part in a Rust paramter `x: u32` to a C# equivalent. Might convert pointers to `out X` or `ref X`.
     fn to_type_specifier(&self, x: &CType) -> String;

--- a/backends/c/src/writer.rs
+++ b/backends/c/src/writer.rs
@@ -228,8 +228,12 @@ pub trait CWriter {
         let name = self.converter().named_callback_to_typename(the_type);
 
         let mut params = Vec::new();
-        for (i, param) in the_type.fnpointer().signature().params().iter().enumerate() {
-            params.push(format!("{} x{}", self.converter().to_type_specifier(param.the_type()), i));
+        for param in the_type.fnpointer().signature().params().iter() {
+            params.push(format!(
+                "{} {}",
+                self.converter().to_type_specifier(param.the_type()),
+                param.name().to_naming_style(&self.config().function_parameter_naming)
+            ));
         }
 
         indented!(w, "{}", format!("typedef {} (*{})({});", rval, name, params.join(", ")))?;

--- a/backends/c/tests/output_docs_inline/my_header.h
+++ b/backends/c/tests/output_docs_inline/my_header.h
@@ -135,8 +135,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
+typedef uint8_t (*my_library_callback_u8)(uint8_t x0);
 
-typedef uint32_t (*my_library_fptr_fn_u32_rval_u32)(uint32_t x0);
+typedef uint32_t (*my_library_my_callback)(uint32_t x0);
 
 typedef struct my_library_array
 {
@@ -202,7 +203,7 @@ typedef struct my_library_option_inner
     uint8_t is_some;
 } my_library_option_inner;
 
-typedef void (*my_library_fptr_fn_pconst)(const void* x0);
+typedef void (*my_library_my_callback_void)(const void* x0);
 
 ///A pointer to an array of data someone else owns which may not be modified.
 typedef struct my_library_slice_use_ascii_string_pattern
@@ -218,11 +219,11 @@ typedef struct my_library_slice_vec3f32
     uint64_t len;
 } my_library_slice_vec3f32;
 
-typedef uint8_t (*my_library_fptr_fn_Sliceu8_rval_u8)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callback_ffi_slice)(my_library_sliceu8 x0);
 
-typedef void (*my_library_fptr_fn_SliceMutu8)(my_library_slice_mutu8 x0);
+typedef void (*my_library_callback_slice_mut)(my_library_slice_mutu8 x0);
 
-typedef my_library_vec3f32 (*my_library_fptr_fn_SliceVec3f32_rval_Vec3f32)(my_library_slice_vec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callback_huge_vec_slice)(my_library_slice_vec3f32 x0);
 
 
 void primitive_void();

--- a/backends/c/tests/output_docs_inline/my_header.h
+++ b/backends/c/tests/output_docs_inline/my_header.h
@@ -135,9 +135,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
-typedef uint8_t (*my_library_callback_u8)(uint8_t x0);
+typedef uint8_t (*my_library_callback_u8)(uint8_t value);
 
-typedef uint32_t (*my_library_my_callback)(uint32_t x0);
+typedef uint32_t (*my_library_my_callback)(uint32_t value);
 
 typedef struct my_library_array
 {
@@ -203,7 +203,7 @@ typedef struct my_library_option_inner
     uint8_t is_some;
 } my_library_option_inner;
 
-typedef void (*my_library_my_callback_void)(const void* x0);
+typedef void (*my_library_my_callback_void)(const void* ptr);
 
 ///A pointer to an array of data someone else owns which may not be modified.
 typedef struct my_library_slice_use_ascii_string_pattern
@@ -219,11 +219,11 @@ typedef struct my_library_slice_vec3f32
     uint64_t len;
 } my_library_slice_vec3f32;
 
-typedef uint8_t (*my_library_callback_ffi_slice)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callback_ffi_slice)(my_library_sliceu8 slice);
 
-typedef void (*my_library_callback_slice_mut)(my_library_slice_mutu8 x0);
+typedef void (*my_library_callback_slice_mut)(my_library_slice_mutu8 slice);
 
-typedef my_library_vec3f32 (*my_library_callback_huge_vec_slice)(my_library_slice_vec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callback_huge_vec_slice)(my_library_slice_vec3f32 slice);
 
 
 void primitive_void();

--- a/backends/c/tests/output_docs_inline/my_header.h.expected
+++ b/backends/c/tests/output_docs_inline/my_header.h.expected
@@ -135,8 +135,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
+typedef uint8_t (*my_library_callback_u8)(uint8_t x0);
 
-typedef uint32_t (*my_library_fptr_fn_u32_rval_u32)(uint32_t x0);
+typedef uint32_t (*my_library_my_callback)(uint32_t x0);
 
 typedef struct my_library_array
 {
@@ -202,7 +203,7 @@ typedef struct my_library_option_inner
     uint8_t is_some;
 } my_library_option_inner;
 
-typedef void (*my_library_fptr_fn_pconst)(const void* x0);
+typedef void (*my_library_my_callback_void)(const void* x0);
 
 ///A pointer to an array of data someone else owns which may not be modified.
 typedef struct my_library_slice_use_ascii_string_pattern
@@ -218,11 +219,11 @@ typedef struct my_library_slice_vec3f32
     uint64_t len;
 } my_library_slice_vec3f32;
 
-typedef uint8_t (*my_library_fptr_fn_Sliceu8_rval_u8)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callback_ffi_slice)(my_library_sliceu8 x0);
 
-typedef void (*my_library_fptr_fn_SliceMutu8)(my_library_slice_mutu8 x0);
+typedef void (*my_library_callback_slice_mut)(my_library_slice_mutu8 x0);
 
-typedef my_library_vec3f32 (*my_library_fptr_fn_SliceVec3f32_rval_Vec3f32)(my_library_slice_vec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callback_huge_vec_slice)(my_library_slice_vec3f32 x0);
 
 
 void primitive_void();

--- a/backends/c/tests/output_docs_inline/my_header.h.expected
+++ b/backends/c/tests/output_docs_inline/my_header.h.expected
@@ -135,9 +135,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
-typedef uint8_t (*my_library_callback_u8)(uint8_t x0);
+typedef uint8_t (*my_library_callback_u8)(uint8_t value);
 
-typedef uint32_t (*my_library_my_callback)(uint32_t x0);
+typedef uint32_t (*my_library_my_callback)(uint32_t value);
 
 typedef struct my_library_array
 {
@@ -203,7 +203,7 @@ typedef struct my_library_option_inner
     uint8_t is_some;
 } my_library_option_inner;
 
-typedef void (*my_library_my_callback_void)(const void* x0);
+typedef void (*my_library_my_callback_void)(const void* ptr);
 
 ///A pointer to an array of data someone else owns which may not be modified.
 typedef struct my_library_slice_use_ascii_string_pattern
@@ -219,11 +219,11 @@ typedef struct my_library_slice_vec3f32
     uint64_t len;
 } my_library_slice_vec3f32;
 
-typedef uint8_t (*my_library_callback_ffi_slice)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callback_ffi_slice)(my_library_sliceu8 slice);
 
-typedef void (*my_library_callback_slice_mut)(my_library_slice_mutu8 x0);
+typedef void (*my_library_callback_slice_mut)(my_library_slice_mutu8 slice);
 
-typedef my_library_vec3f32 (*my_library_callback_huge_vec_slice)(my_library_slice_vec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callback_huge_vec_slice)(my_library_slice_vec3f32 slice);
 
 
 void primitive_void();

--- a/backends/c/tests/output_nodocs/my_header.h
+++ b/backends/c/tests/output_nodocs/my_header.h
@@ -126,9 +126,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
-typedef uint8_t (*my_library_callbacku8)(uint8_t x0);
+typedef uint8_t (*my_library_callbacku8)(uint8_t value);
 
-typedef uint32_t (*my_library_mycallback)(uint32_t x0);
+typedef uint32_t (*my_library_mycallback)(uint32_t value);
 
 typedef struct my_library_array
     {
@@ -188,7 +188,7 @@ typedef struct my_library_optioninner
     uint8_t is_some;
     } my_library_optioninner;
 
-typedef void (*my_library_mycallbackvoid)(const void* x0);
+typedef void (*my_library_mycallbackvoid)(const void* ptr);
 
 typedef struct my_library_sliceuseasciistringpattern
     {
@@ -202,11 +202,11 @@ typedef struct my_library_slicevec3f32
     uint64_t len;
     } my_library_slicevec3f32;
 
-typedef uint8_t (*my_library_callbackffislice)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callbackffislice)(my_library_sliceu8 slice);
 
-typedef void (*my_library_callbackslicemut)(my_library_slicemutu8 x0);
+typedef void (*my_library_callbackslicemut)(my_library_slicemutu8 slice);
 
-typedef my_library_vec3f32 (*my_library_callbackhugevecslice)(my_library_slicevec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callbackhugevecslice)(my_library_slicevec3f32 slice);
 
 
 void primitive_void();

--- a/backends/c/tests/output_nodocs/my_header.h
+++ b/backends/c/tests/output_nodocs/my_header.h
@@ -126,8 +126,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
+typedef uint8_t (*my_library_callbacku8)(uint8_t x0);
 
-typedef uint32_t (*my_library_fptr_fn_u32_rval_u32)(uint32_t x0);
+typedef uint32_t (*my_library_mycallback)(uint32_t x0);
 
 typedef struct my_library_array
     {
@@ -187,7 +188,7 @@ typedef struct my_library_optioninner
     uint8_t is_some;
     } my_library_optioninner;
 
-typedef void (*my_library_fptr_fn_pconst)(const void* x0);
+typedef void (*my_library_mycallbackvoid)(const void* x0);
 
 typedef struct my_library_sliceuseasciistringpattern
     {
@@ -201,11 +202,11 @@ typedef struct my_library_slicevec3f32
     uint64_t len;
     } my_library_slicevec3f32;
 
-typedef uint8_t (*my_library_fptr_fn_Sliceu8_rval_u8)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callbackffislice)(my_library_sliceu8 x0);
 
-typedef void (*my_library_fptr_fn_SliceMutu8)(my_library_slicemutu8 x0);
+typedef void (*my_library_callbackslicemut)(my_library_slicemutu8 x0);
 
-typedef my_library_vec3f32 (*my_library_fptr_fn_SliceVec3f32_rval_Vec3f32)(my_library_slicevec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callbackhugevecslice)(my_library_slicevec3f32 x0);
 
 
 void primitive_void();

--- a/backends/c/tests/output_nodocs/my_header.h.expected
+++ b/backends/c/tests/output_nodocs/my_header.h.expected
@@ -126,9 +126,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
-typedef uint8_t (*my_library_callbacku8)(uint8_t x0);
+typedef uint8_t (*my_library_callbacku8)(uint8_t value);
 
-typedef uint32_t (*my_library_mycallback)(uint32_t x0);
+typedef uint32_t (*my_library_mycallback)(uint32_t value);
 
 typedef struct my_library_array
     {
@@ -188,7 +188,7 @@ typedef struct my_library_optioninner
     uint8_t is_some;
     } my_library_optioninner;
 
-typedef void (*my_library_mycallbackvoid)(const void* x0);
+typedef void (*my_library_mycallbackvoid)(const void* ptr);
 
 typedef struct my_library_sliceuseasciistringpattern
     {
@@ -202,11 +202,11 @@ typedef struct my_library_slicevec3f32
     uint64_t len;
     } my_library_slicevec3f32;
 
-typedef uint8_t (*my_library_callbackffislice)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callbackffislice)(my_library_sliceu8 slice);
 
-typedef void (*my_library_callbackslicemut)(my_library_slicemutu8 x0);
+typedef void (*my_library_callbackslicemut)(my_library_slicemutu8 slice);
 
-typedef my_library_vec3f32 (*my_library_callbackhugevecslice)(my_library_slicevec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callbackhugevecslice)(my_library_slicevec3f32 slice);
 
 
 void primitive_void();

--- a/backends/c/tests/output_nodocs/my_header.h.expected
+++ b/backends/c/tests/output_nodocs/my_header.h.expected
@@ -126,8 +126,9 @@ typedef struct my_library_weird1u32
 
 typedef uint8_t (*my_library_fptr_fn_u8_rval_u8)(uint8_t x0);
 
+typedef uint8_t (*my_library_callbacku8)(uint8_t x0);
 
-typedef uint32_t (*my_library_fptr_fn_u32_rval_u32)(uint32_t x0);
+typedef uint32_t (*my_library_mycallback)(uint32_t x0);
 
 typedef struct my_library_array
     {
@@ -187,7 +188,7 @@ typedef struct my_library_optioninner
     uint8_t is_some;
     } my_library_optioninner;
 
-typedef void (*my_library_fptr_fn_pconst)(const void* x0);
+typedef void (*my_library_mycallbackvoid)(const void* x0);
 
 typedef struct my_library_sliceuseasciistringpattern
     {
@@ -201,11 +202,11 @@ typedef struct my_library_slicevec3f32
     uint64_t len;
     } my_library_slicevec3f32;
 
-typedef uint8_t (*my_library_fptr_fn_Sliceu8_rval_u8)(my_library_sliceu8 x0);
+typedef uint8_t (*my_library_callbackffislice)(my_library_sliceu8 x0);
 
-typedef void (*my_library_fptr_fn_SliceMutu8)(my_library_slicemutu8 x0);
+typedef void (*my_library_callbackslicemut)(my_library_slicemutu8 x0);
 
-typedef my_library_vec3f32 (*my_library_fptr_fn_SliceVec3f32_rval_Vec3f32)(my_library_slicevec3f32 x0);
+typedef my_library_vec3f32 (*my_library_callbackhugevecslice)(my_library_slicevec3f32 x0);
 
 
 void primitive_void();

--- a/backends/csharp/benches/Interop.common.cs
+++ b/backends/csharp/benches/Interop.common.cs
@@ -585,22 +585,22 @@ namespace My.Company.Common
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
 

--- a/backends/csharp/benches/Interop.cs
+++ b/backends/csharp/benches/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 16709214448368826139ul)
+            if (api_version != 10027021407890840897ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (16709214448368826139). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (10027021407890840897). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -1194,22 +1194,22 @@ namespace My.Company
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
     /// Some struct we want to expose as a class.

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -91,7 +91,7 @@ pub trait CSharpWriter {
             let version = inventory_hash(self.inventory());
             let flavor = match self.config().rename_symbols {
                 true => FunctionNameFlavor::CSharpMethodNameWithClass,
-                false => FunctionNameFlavor::RawFFIName
+                false => FunctionNameFlavor::RawFFIName,
             };
             let fn_call = self.converter().function_name_to_csharp_name(api_guard, flavor);
             indented!(w, [_], r#"var api_version = {}.{}();"#, self.config().class, fn_call)?;
@@ -171,10 +171,13 @@ pub trait CSharpWriter {
 
     fn write_function_declaration(&self, w: &mut IndentWriter, function: &Function) -> Result<(), Error> {
         let rval = self.converter().function_rval_to_csharp_typename(function);
-        let name = self.converter().function_name_to_csharp_name(function, match self.config().rename_symbols {
-            true => FunctionNameFlavor::CSharpMethodNameWithClass,
-            false => FunctionNameFlavor::RawFFIName
-        });
+        let name = self.converter().function_name_to_csharp_name(
+            function,
+            match self.config().rename_symbols {
+                true => FunctionNameFlavor::CSharpMethodNameWithClass,
+                false => FunctionNameFlavor::RawFFIName,
+            },
+        );
 
         let mut params = Vec::new();
         for (_, p) in function.signature().params().iter().enumerate() {
@@ -306,8 +309,8 @@ pub trait CSharpWriter {
         let visibility = self.config().visibility_types.to_access_modifier();
 
         let mut params = Vec::new();
-        for (i, param) in the_type.fnpointer().signature().params().iter().enumerate() {
-            params.push(format!("{} x{}", self.converter().to_typespecifier_in_param(param.the_type()), i));
+        for param in the_type.fnpointer().signature().params().iter() {
+            params.push(format!("{} {}", self.converter().to_typespecifier_in_param(param.the_type()), param.name()));
         }
 
         indented!(w, r#"{} delegate {} {}({});"#, visibility, rval, name, params.join(", "))
@@ -865,7 +868,9 @@ pub trait CSharpWriter {
 
         for ctor in class.constructors() {
             // Ctor
-            let fn_name = self.converter().function_name_to_csharp_name(ctor, FunctionNameFlavor::CSharpMethodNameWithoutClass(&common_prefix));
+            let fn_name = self
+                .converter()
+                .function_name_to_csharp_name(ctor, FunctionNameFlavor::CSharpMethodNameWithoutClass(&common_prefix));
             let rval = format!("static {}", context_type_name);
 
             self.write_documentation(w, ctor.meta().documentation())?;
@@ -879,7 +884,9 @@ pub trait CSharpWriter {
 
         for function in class.methods() {
             // Main function
-            let fn_name = self.converter().function_name_to_csharp_name(function, FunctionNameFlavor::CSharpMethodNameWithoutClass(&common_prefix));
+            let fn_name = self
+                .converter()
+                .function_name_to_csharp_name(function, FunctionNameFlavor::CSharpMethodNameWithoutClass(&common_prefix));
 
             // Write checked method. These are "normal" methods that accept
             // common C# types.

--- a/backends/csharp/tests/output_safe/Interop.common.cs
+++ b/backends/csharp/tests/output_safe/Interop.common.cs
@@ -352,22 +352,22 @@ namespace My.Company.Common
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
 

--- a/backends/csharp/tests/output_safe/Interop.common.cs.expected
+++ b/backends/csharp/tests/output_safe/Interop.common.cs.expected
@@ -352,22 +352,22 @@ namespace My.Company.Common
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
 

--- a/backends/csharp/tests/output_safe/Interop.cs
+++ b/backends/csharp/tests/output_safe/Interop.cs
@@ -18,9 +18,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 16709214448368826139ul)
+            if (api_version != 10027021407890840897ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (16709214448368826139). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (10027021407890840897). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -994,22 +994,22 @@ namespace My.Company
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
     /// Some struct we want to expose as a class.

--- a/backends/csharp/tests/output_safe/Interop.cs.expected
+++ b/backends/csharp/tests/output_safe/Interop.cs.expected
@@ -18,9 +18,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 16709214448368826139ul)
+            if (api_version != 10027021407890840897ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (16709214448368826139). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (10027021407890840897). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -994,22 +994,22 @@ namespace My.Company
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
     /// Some struct we want to expose as a class.

--- a/backends/csharp/tests/output_unity/Assets/Interop.common.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.common.cs
@@ -585,22 +585,22 @@ namespace My.Company.Common
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
 

--- a/backends/csharp/tests/output_unity/Assets/Interop.common.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.common.cs.expected
@@ -585,22 +585,22 @@ namespace My.Company.Common
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
 

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 16709214448368826139ul)
+            if (api_version != 10027021407890840897ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (16709214448368826139). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (10027021407890840897). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -1194,22 +1194,22 @@ namespace My.Company
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
     /// Some struct we want to expose as a class.

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 16709214448368826139ul)
+            if (api_version != 10027021407890840897ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (16709214448368826139). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (10027021407890840897). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -1194,22 +1194,22 @@ namespace My.Company
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
     /// Some struct we want to expose as a class.

--- a/backends/csharp/tests/output_unsafe/Interop.common.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.common.cs
@@ -585,22 +585,22 @@ namespace My.Company.Common
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
 

--- a/backends/csharp/tests/output_unsafe/Interop.common.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.common.cs.expected
@@ -585,22 +585,22 @@ namespace My.Company.Common
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
 

--- a/backends/csharp/tests/output_unsafe/Interop.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 16709214448368826139ul)
+            if (api_version != 10027021407890840897ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (16709214448368826139). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (10027021407890840897). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -1194,22 +1194,22 @@ namespace My.Company
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
     /// Some struct we want to expose as a class.

--- a/backends/csharp/tests/output_unsafe/Interop.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.cs.expected
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 16709214448368826139ul)
+            if (api_version != 10027021407890840897ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (16709214448368826139). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (10027021407890840897). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -1194,22 +1194,22 @@ namespace My.Company
 
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackFFISlice(Sliceu8 x0);
+    public delegate byte CallbackFFISlice(Sliceu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 x0);
+    public delegate Vec3f32 CallbackHugeVecSlice(SliceVec3f32 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void CallbackSliceMut(SliceMutu8 x0);
+    public delegate void CallbackSliceMut(SliceMutu8 slice);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate byte CallbackU8(byte x0);
+    public delegate byte CallbackU8(byte value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate uint MyCallback(uint x0);
+    public delegate uint MyCallback(uint value);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void MyCallbackVoid(IntPtr x0);
+    public delegate void MyCallbackVoid(IntPtr ptr);
 
 
     /// Some struct we want to expose as a class.

--- a/reference_project/src/patterns/callbacks.rs
+++ b/reference_project/src/patterns/callbacks.rs
@@ -1,7 +1,7 @@
 use interoptopus::{callback, ffi_function};
 use std::ffi::c_void;
 
-callback!(MyCallback(x: u32) -> u32);
+callback!(MyCallback(value: u32) -> u32);
 callback!(MyCallbackVoid(ptr: *const c_void));
 
 #[ffi_function]

--- a/reference_project/src/patterns/slice.rs
+++ b/reference_project/src/patterns/slice.rs
@@ -6,7 +6,7 @@ static HUGE_VEC_SLICE: [Vec3f32; 100_000] = [Vec3f32 { x: 0.0, y: 0.0, z: 0.0 };
 
 callback!(CallbackHugeVecSlice(slice: FFISlice<Vec3f32>) -> Vec3f32);
 callback!(CallbackSliceMut(slice: FFISliceMut<'_, u8>) -> ());
-callback!(CallbackU8(x: u8) -> u8);
+callback!(CallbackU8(value: u8) -> u8);
 
 #[ffi_function]
 #[no_mangle]


### PR DESCRIPTION
I have also added a `call_if_some` function to the callback macro which allows callbacks to be optionally called (without panicing if the fn ptr is null).