### PR TITLE
Fix Python negative slice index and check index range

### DIFF
--- a/backends/cpython/src/writer.rs
+++ b/backends/cpython/src/writer.rs
@@ -307,12 +307,28 @@ pub trait PythonWriter {
         indented!(w, [_ _], r#"return self.len"#)?;
         w.newline()?;
         indented!(w, [_], r#"def __getitem__(self, i){}:"#, hint_out)?;
-        indented!(w, [_ _], r#"return self.data[i]"#)?;
+        indented!(w, [_ _], r#"if i < 0:"#)?;
+        indented!(w, [_ _ _], r#"index = self.len+i"#)?;
+        indented!(w, [_ _], r#"else:"#)?;
+        indented!(w, [_ _ _], r#"index = i"#)?;
+        w.newline()?;
+        indented!(w, [_ _], r#"if index >= self.len:"#)?;
+        indented!(w, [_ _ _], r#"raise IndexError("Index out of range")"#)?;
+        w.newline()?;
+        indented!(w, [_ _], r#"return self.data[index]"#)?;
 
         if mutable {
             w.newline()?;
             indented!(w, [_], r#"def __setitem__(self, i, v{}):"#, hint_in)?;
-            indented!(w, [_ _], r#"self.data[i] = v"#)?;
+            indented!(w, [_ _], r#"if i < 0:"#)?;
+            indented!(w, [_ _ _], r#"index = self.len+i"#)?;
+            indented!(w, [_ _], r#"else:"#)?;
+            indented!(w, [_ _ _], r#"index = i"#)?;
+            w.newline()?;
+            indented!(w, [_ _], r#"if index >= self.len:"#)?;
+            indented!(w, [_ _ _], r#"raise IndexError("Index out of range")"#)?;
+            w.newline()?;
+            indented!(w, [_ _], r#"self.data[index] = v"#)?;
         }
 
         w.newline()?;

--- a/backends/cpython/tests/output/reference_project.py
+++ b/backends/cpython/tests/output/reference_project.py
@@ -987,7 +987,15 @@ class SliceBool(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i):
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceBool:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1029,7 +1037,15 @@ class Sliceu32(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> Sliceu32:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1071,7 +1087,15 @@ class Sliceu8(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> Sliceu8:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1120,10 +1144,26 @@ class SliceMutu32(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def __setitem__(self, i, v: int):
-        self.data[i] = v
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        self.data[index] = v
 
     def copied(self) -> SliceMutu32:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1165,10 +1205,26 @@ class SliceMutu8(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def __setitem__(self, i, v: int):
-        self.data[i] = v
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        self.data[index] = v
 
     def copied(self) -> SliceMutu8:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1267,7 +1323,15 @@ class SliceUseAsciiStringPattern(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> UseAsciiStringPattern:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceUseAsciiStringPattern:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1309,7 +1373,15 @@ class SliceVec(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> Vec:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceVec:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1351,7 +1423,15 @@ class SliceVec3f32(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> Vec3f32:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceVec3f32:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1393,10 +1473,26 @@ class SliceMutVec(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> Vec:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def __setitem__(self, i, v: Vec):
-        self.data[i] = v
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        self.data[index] = v
 
     def copied(self) -> SliceMutVec:
         """Returns a shallow, owned copy of the underlying slice.

--- a/backends/cpython/tests/output/reference_project.py.expected
+++ b/backends/cpython/tests/output/reference_project.py.expected
@@ -987,7 +987,15 @@ class SliceBool(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i):
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceBool:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1029,7 +1037,15 @@ class Sliceu32(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> Sliceu32:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1071,7 +1087,15 @@ class Sliceu8(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> Sliceu8:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1120,10 +1144,26 @@ class SliceMutu32(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def __setitem__(self, i, v: int):
-        self.data[i] = v
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        self.data[index] = v
 
     def copied(self) -> SliceMutu32:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1165,10 +1205,26 @@ class SliceMutu8(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> int:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def __setitem__(self, i, v: int):
-        self.data[i] = v
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        self.data[index] = v
 
     def copied(self) -> SliceMutu8:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1267,7 +1323,15 @@ class SliceUseAsciiStringPattern(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> UseAsciiStringPattern:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceUseAsciiStringPattern:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1309,7 +1373,15 @@ class SliceVec(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> Vec:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceVec:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1351,7 +1423,15 @@ class SliceVec3f32(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> Vec3f32:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def copied(self) -> SliceVec3f32:
         """Returns a shallow, owned copy of the underlying slice.
@@ -1393,10 +1473,26 @@ class SliceMutVec(ctypes.Structure):
         return self.len
 
     def __getitem__(self, i) -> Vec:
-        return self.data[i]
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        return self.data[index]
 
     def __setitem__(self, i, v: Vec):
-        self.data[i] = v
+        if i < 0:
+            index = self.len+i
+        else:
+            index = i
+
+        if index >= self.len:
+            raise IndexError("Index out of range")
+
+        self.data[index] = v
 
     def copied(self) -> SliceMutVec:
         """Returns a shallow, owned copy of the underlying slice.

--- a/backends/cpython/tests/output/tests.py
+++ b/backends/cpython/tests/output/tests.py
@@ -141,11 +141,17 @@ class TestPatterns(unittest.TestCase):
     def test_c_char(self):
         self.assertEqual(b'X', r.pattern_ffi_cchar(b'X'))
 
-    def test_slice(self):
+    def test_slice_callback(self):
         def callback(x):
             self.assertEqual(9, x[-1])
             self.assertEqual(9, x.last())
             self.assertEqual(9, x.bytearray()[-1])
+            try:
+                i = x[10]
+                self.assertFalse(True, "Index out of error should throw exception")
+            except IndexError:
+                pass
+
             return 0
 
         r.pattern_ffi_slice_delegate(callback)

--- a/backends/csharp/src/overloads/dotnet.rs
+++ b/backends/csharp/src/overloads/dotnet.rs
@@ -181,7 +181,6 @@ impl OverloadWriter for DotNet {
             params.push(format!("{} {}", native, name));
         }
 
-
         let signature = format!(r#"public static {} {}({})"#, rval, this_name, params.join(", "));
         if write_for == WriteFor::Docs {
             indented!(w, r#"{};"#, signature)?;

--- a/backends/csharp/src/overloads/unity.rs
+++ b/backends/csharp/src/overloads/unity.rs
@@ -5,7 +5,7 @@ use interoptopus::lang::c::{CType, CompositeType, Field, Function, FunctionSigna
 use interoptopus::patterns::service::Service;
 use interoptopus::patterns::TypePattern;
 use interoptopus::writer::{IndentWriter, WriteFor};
-use interoptopus::{indented, Error, unindented};
+use interoptopus::{indented, unindented, Error};
 use std::ops::Deref;
 
 /// Provides Unity overloads, make sure to use [`Unsafe::UnsafeKeyword`](crate::Unsafe::UnsafeKeyword) or higher.
@@ -145,7 +145,6 @@ impl Unity {
 
         Ok(())
     }
-
 }
 
 impl OverloadWriter for Unity {
@@ -208,8 +207,7 @@ impl OverloadWriter for Unity {
 
         if write_for == WriteFor::Code {
             indented!(w, r#"#if UNITY_2018_1_OR_NEWER"#)?;
-        }
-        else {
+        } else {
             unindented!(w, r#"#if UNITY_2018_1_OR_NEWER"#)?;
         }
 
@@ -326,8 +324,7 @@ impl OverloadWriter for Unity {
         if write_for == WriteFor::Code {
             w.newline()?;
             indented!(w, r#"#if UNITY_2018_1_OR_NEWER"#)?;
-        }
-        else {
+        } else {
             unindented!(w, r#"#if UNITY_2018_1_OR_NEWER"#)?;
         }
         if write_for == WriteFor::Code {
@@ -343,11 +340,9 @@ impl OverloadWriter for Unity {
             write_for,
         )?;
 
-
         if write_for == WriteFor::Code {
             indented!(w, r#"#endif"#)?;
-        }
-        else {
+        } else {
             unindented!(w, r#"#endif"#)?;
         }
 

--- a/core/src/writer.rs
+++ b/core/src/writer.rs
@@ -140,7 +140,6 @@ macro_rules! indented {
     };
 }
 
-
 /// Writes an unindented line of code. Used in backends.
 #[macro_export]
 macro_rules! unindented {

--- a/reference_project/src/functions.rs
+++ b/reference_project/src/functions.rs
@@ -5,13 +5,13 @@ use crate::types::{
     ambiguous1, ambiguous2, common, some_foreign_type, Array, Callbacku8u8, EnumDocumented, EnumRenamedXYZ, Generic, Generic2, Generic3, Generic4, Opaque, Phantom,
     SomeForeignType, StructDocumented, StructRenamedXYZ, Transparent, Tupled, Vec3f32, Visibility1, Visibility2, Weird1, Weird2,
 };
+use interoptopus::patterns::option::FFIOption;
 use interoptopus::patterns::result::panics_and_errors_to_ffi_enum;
+use interoptopus::patterns::slice::FFISlice;
+use interoptopus::patterns::slice::FFISliceMut;
 use interoptopus::{ffi_function, ffi_surrogates, here};
 use std::ptr::null;
 use std::time::Duration;
-use interoptopus::patterns::option::FFIOption;
-use interoptopus::patterns::slice::FFISlice;
-use interoptopus::patterns::slice::FFISliceMut;
 
 #[ffi_function]
 #[no_mangle]


### PR DESCRIPTION
Previously, if you accessed a slice by a negative index in Python, the slice was accessed out of bounds. This change makes it so that it behaves as the normal Python index accessor. This change also ensures that slices are not accessed by indexed out of bounds.