### PR TITLE
Allow ctypes array for slice parameters in Python

### DIFF
--- a/backends/cpython/src/writer.rs
+++ b/backends/cpython/src/writer.rs
@@ -276,11 +276,12 @@ pub trait PythonWriter {
                     },
                     TypePattern::Slice(t) | TypePattern::SliceMut(t) => {
                         let inner = self.converter().to_ctypes_name(
-                            t.fields().iter().find(|i| i.name().eq_ignore_ascii_case("data")).expect("slice must have a data field").the_type().deref_pointer().expect("data must be a pointer type"),
+                            t.fields().iter().find(|i| i.name().eq_ignore_ascii_case("data"))
+                                .expect("slice must have a data field").the_type().deref_pointer().expect("data must be a pointer type"),
                             false);
 
-                        indented!(w, [_], r#"if hasattr({}, "_length_") and hasattr({}, "_type_") and getattr({}, "_type_") == {}:"#,
-                        arg.name(), arg.name(), arg.name(), inner)?;
+                        indented!(w, [_], r#"if hasattr({}, "_length_") and getattr({}, "_type_", "") == {}:"#,
+                        arg.name(), arg.name(), inner)?;
 
                         indented!(w, [_ _], r#"{} = {}(data=ctypes.cast({}, ctypes.POINTER({})), len=len({}))"#,
                                 arg.name(), arg.the_type().name_within_lib(), arg.name(), inner, arg.name())?;

--- a/backends/cpython/tests/output/reference_project.md
+++ b/backends/cpython/tests/output/reference_project.md
@@ -1121,7 +1121,7 @@ def namespaced_inner_option(x: OptionVec) -> OptionVec:
 ## namespaced_inner_slice 
 #### Definition 
 ```python
-def namespaced_inner_slice(x: SliceVec) -> SliceVec:
+def namespaced_inner_slice(x: SliceVec | ctypes.Array[Vec]) -> SliceVec:
     ...
 ```
 
@@ -1130,7 +1130,7 @@ def namespaced_inner_slice(x: SliceVec) -> SliceVec:
 ## namespaced_inner_slice_mut 
 #### Definition 
 ```python
-def namespaced_inner_slice_mut(x: SliceMutVec) -> SliceMutVec:
+def namespaced_inner_slice_mut(x: SliceMutVec | ctypes.Array[Vec]) -> SliceMutVec:
     ...
 ```
 
@@ -1229,7 +1229,7 @@ def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
 ## pattern_ffi_slice_1 
 #### Definition 
 ```python
-def pattern_ffi_slice_1(ffi_slice: Sliceu32) -> int:
+def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
     ...
 ```
 
@@ -1238,7 +1238,7 @@ def pattern_ffi_slice_1(ffi_slice: Sliceu32) -> int:
 ## pattern_ffi_slice_2 
 #### Definition 
 ```python
-def pattern_ffi_slice_2(ffi_slice: SliceVec3f32, i: int) -> Vec3f32:
+def pattern_ffi_slice_2(ffi_slice: SliceVec3f32 | ctypes.Array[Vec3f32], i: int) -> Vec3f32:
     ...
 ```
 
@@ -1247,7 +1247,7 @@ def pattern_ffi_slice_2(ffi_slice: SliceVec3f32, i: int) -> Vec3f32:
 ## pattern_ffi_slice_3 
 #### Definition 
 ```python
-def pattern_ffi_slice_3(slice: SliceMutu8, callback):
+def pattern_ffi_slice_3(slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8], callback):
     ...
 ```
 
@@ -1256,7 +1256,7 @@ def pattern_ffi_slice_3(slice: SliceMutu8, callback):
 ## pattern_ffi_slice_4 
 #### Definition 
 ```python
-def pattern_ffi_slice_4(slice: Sliceu8, slice2: SliceMutu8):
+def pattern_ffi_slice_4(slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
     ...
 ```
 
@@ -1482,7 +1482,7 @@ class SimpleService:
 ```python
 class SimpleService:
 
-    def method_mut_self(self, slice: Sliceu8) -> int:
+    def method_mut_self(self, slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         ...
 ```
 
@@ -1495,7 +1495,7 @@ class SimpleService:
 ```python
 class SimpleService:
 
-    def method_mut_self_void(self, slice: SliceBool):
+    def method_mut_self_void(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         ...
 ```
 
@@ -1519,7 +1519,7 @@ class SimpleService:
 ```python
 class SimpleService:
 
-    def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8) -> int:
+    def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         ...
 ```
 
@@ -1531,7 +1531,7 @@ class SimpleService:
 ```python
 class SimpleService:
 
-    def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8, slice2: Sliceu8) -> int:
+    def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         ...
 ```
 
@@ -1543,7 +1543,7 @@ class SimpleService:
 ```python
 class SimpleService:
 
-    def method_mut_self_ffi_error(self, slice: SliceMutu8):
+    def method_mut_self_ffi_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         ...
 ```
 
@@ -1555,7 +1555,7 @@ class SimpleService:
 ```python
 class SimpleService:
 
-    def method_mut_self_no_error(self, slice: SliceMutu8):
+    def method_mut_self_no_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         ...
 ```
 
@@ -1648,7 +1648,7 @@ class SimpleServiceLifetime:
 ```python
 class SimpleServiceLifetime:
 
-    def method_lt(self, slice: SliceBool):
+    def method_lt(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         ...
 ```
 
@@ -1660,7 +1660,7 @@ class SimpleServiceLifetime:
 ```python
 class SimpleServiceLifetime:
 
-    def method_lt2(self, slice: SliceBool):
+    def method_lt2(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         ...
 ```
 
@@ -1672,7 +1672,7 @@ class SimpleServiceLifetime:
 ```python
 class SimpleServiceLifetime:
 
-    def return_string_accept_slice(self, anon1: Sliceu8) -> str:
+    def return_string_accept_slice(self, anon1: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> str:
         ...
 ```
 

--- a/backends/cpython/tests/output/reference_project.py
+++ b/backends/cpython/tests/output/reference_project.py
@@ -319,10 +319,16 @@ def namespaced_type(x: Vec) -> Vec:
 def namespaced_inner_option(x: OptionVec) -> OptionVec:
     return c_lib.namespaced_inner_option(x)
 
-def namespaced_inner_slice(x: SliceVec) -> SliceVec:
+def namespaced_inner_slice(x: SliceVec | ctypes.Array[Vec]) -> SliceVec:
+    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+        x = SliceVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
+
     return c_lib.namespaced_inner_slice(x)
 
-def namespaced_inner_slice_mut(x: SliceMutVec) -> SliceMutVec:
+def namespaced_inner_slice_mut(x: SliceMutVec | ctypes.Array[Vec]) -> SliceMutVec:
+    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+        x = SliceMutVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
+
     return c_lib.namespaced_inner_slice_mut(x)
 
 def panics():
@@ -360,19 +366,34 @@ def pattern_ascii_pointer_len(x: str, y: UseAsciiStringPattern) -> int:
 def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
 
-def pattern_ffi_slice_1(ffi_slice: Sliceu32) -> int:
+def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
+    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == ctypes.c_uint32:
+        ffi_slice = Sliceu32(data=ctypes.cast(ffi_slice, ctypes.POINTER(ctypes.c_uint32)), len=len(ffi_slice))
+
     return c_lib.pattern_ffi_slice_1(ffi_slice)
 
-def pattern_ffi_slice_2(ffi_slice: SliceVec3f32, i: int) -> Vec3f32:
+def pattern_ffi_slice_2(ffi_slice: SliceVec3f32 | ctypes.Array[Vec3f32], i: int) -> Vec3f32:
+    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == Vec3f32:
+        ffi_slice = SliceVec3f32(data=ctypes.cast(ffi_slice, ctypes.POINTER(Vec3f32)), len=len(ffi_slice))
+
     return c_lib.pattern_ffi_slice_2(ffi_slice, i)
 
-def pattern_ffi_slice_3(slice: SliceMutu8, callback):
+def pattern_ffi_slice_3(slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8], callback):
+    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
     if not hasattr(callback, "__ctypes_from_outparam__"):
         callback = callbacks.fn_SliceMutu8(callback)
 
     return c_lib.pattern_ffi_slice_3(slice, callback)
 
-def pattern_ffi_slice_4(slice: Sliceu8, slice2: SliceMutu8):
+def pattern_ffi_slice_4(slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
+    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
+    if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+        slice2 = SliceMutu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
+
     return c_lib.pattern_ffi_slice_4(slice, slice2)
 
 def pattern_ffi_slice_5(slice: ctypes.POINTER(Sliceu8), slice2: ctypes.POINTER(SliceMutu8)):
@@ -1599,32 +1620,53 @@ class SimpleService:
  Multiple lines."""
         return c_lib.simple_service_method_void(self._ctx, )
 
-    def method_mut_self(self, slice: Sliceu8) -> int:
+    def method_mut_self(self, slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self(self._ctx, slice)
 
-    def method_mut_self_void(self, slice: SliceBool):
+    def method_mut_self_void(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """ Single line."""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_void(self._ctx, slice)
 
     def method_mut_self_ref(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8)) -> int:
         """"""
         return c_lib.simple_service_method_mut_self_ref(self._ctx, x, y)
 
-    def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8) -> int:
+    def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_ref_slice(self._ctx, x, y, slice)
 
-    def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8, slice2: Sliceu8) -> int:
+    def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
+        if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+            slice2 = Sliceu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
+
         return c_lib.simple_service_method_mut_self_ref_slice_limited(self._ctx, x, y, slice, slice2)
 
-    def method_mut_self_ffi_error(self, slice: SliceMutu8):
+    def method_mut_self_ffi_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_ffi_error(self._ctx, slice)
 
-    def method_mut_self_no_error(self, slice: SliceMutu8):
+    def method_mut_self_no_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_no_error(self._ctx, slice)
 
     def return_slice(self, ) -> Sliceu32:
@@ -1676,16 +1718,25 @@ class SimpleServiceLifetime:
 
     def __del__(self):
         c_lib.simple_service_lt_destroy(self._ctx, )
-    def method_lt(self, slice: SliceBool):
+    def method_lt(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_lt_method_lt(self._ctx, slice)
 
-    def method_lt2(self, slice: SliceBool):
+    def method_lt2(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_lt_method_lt2(self._ctx, slice)
 
-    def return_string_accept_slice(self, anon1: Sliceu8) -> str:
+    def return_string_accept_slice(self, anon1: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> str:
         """"""
+        if hasattr(anon1, "_length_") and hasattr(anon1, "_type_") and getattr(anon1, "_type_") == ctypes.c_uint8:
+            anon1 = Sliceu8(data=ctypes.cast(anon1, ctypes.POINTER(ctypes.c_uint8)), len=len(anon1))
+
         rval = c_lib.simple_service_lt_return_string_accept_slice(self._ctx, anon1)
         return ctypes.string_at(rval)
 

--- a/backends/cpython/tests/output/reference_project.py
+++ b/backends/cpython/tests/output/reference_project.py
@@ -320,13 +320,13 @@ def namespaced_inner_option(x: OptionVec) -> OptionVec:
     return c_lib.namespaced_inner_option(x)
 
 def namespaced_inner_slice(x: SliceVec | ctypes.Array[Vec]) -> SliceVec:
-    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+    if hasattr(x, "_length_") and getattr(x, "_type_", "") == Vec:
         x = SliceVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
 
     return c_lib.namespaced_inner_slice(x)
 
 def namespaced_inner_slice_mut(x: SliceMutVec | ctypes.Array[Vec]) -> SliceMutVec:
-    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+    if hasattr(x, "_length_") and getattr(x, "_type_", "") == Vec:
         x = SliceMutVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
 
     return c_lib.namespaced_inner_slice_mut(x)
@@ -367,19 +367,19 @@ def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
 
 def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
-    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == ctypes.c_uint32:
+    if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == ctypes.c_uint32:
         ffi_slice = Sliceu32(data=ctypes.cast(ffi_slice, ctypes.POINTER(ctypes.c_uint32)), len=len(ffi_slice))
 
     return c_lib.pattern_ffi_slice_1(ffi_slice)
 
 def pattern_ffi_slice_2(ffi_slice: SliceVec3f32 | ctypes.Array[Vec3f32], i: int) -> Vec3f32:
-    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == Vec3f32:
+    if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == Vec3f32:
         ffi_slice = SliceVec3f32(data=ctypes.cast(ffi_slice, ctypes.POINTER(Vec3f32)), len=len(ffi_slice))
 
     return c_lib.pattern_ffi_slice_2(ffi_slice, i)
 
 def pattern_ffi_slice_3(slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8], callback):
-    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+    if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
         slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
     if not hasattr(callback, "__ctypes_from_outparam__"):
@@ -388,10 +388,10 @@ def pattern_ffi_slice_3(slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8], callba
     return c_lib.pattern_ffi_slice_3(slice, callback)
 
 def pattern_ffi_slice_4(slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
-    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+    if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
         slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
-    if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+    if hasattr(slice2, "_length_") and getattr(slice2, "_type_", "") == ctypes.c_uint8:
         slice2 = SliceMutu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
 
     return c_lib.pattern_ffi_slice_4(slice, slice2)
@@ -1622,14 +1622,14 @@ class SimpleService:
 
     def method_mut_self(self, slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self(self._ctx, slice)
 
     def method_mut_self_void(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """ Single line."""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_void(self._ctx, slice)
@@ -1640,31 +1640,31 @@ class SimpleService:
 
     def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_ref_slice(self._ctx, x, y, slice)
 
     def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
-        if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+        if hasattr(slice2, "_length_") and getattr(slice2, "_type_", "") == ctypes.c_uint8:
             slice2 = Sliceu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
 
         return c_lib.simple_service_method_mut_self_ref_slice_limited(self._ctx, x, y, slice, slice2)
 
     def method_mut_self_ffi_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_ffi_error(self._ctx, slice)
 
     def method_mut_self_no_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_no_error(self._ctx, slice)
@@ -1720,21 +1720,21 @@ class SimpleServiceLifetime:
         c_lib.simple_service_lt_destroy(self._ctx, )
     def method_lt(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_lt_method_lt(self._ctx, slice)
 
     def method_lt2(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_lt_method_lt2(self._ctx, slice)
 
     def return_string_accept_slice(self, anon1: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> str:
         """"""
-        if hasattr(anon1, "_length_") and hasattr(anon1, "_type_") and getattr(anon1, "_type_") == ctypes.c_uint8:
+        if hasattr(anon1, "_length_") and getattr(anon1, "_type_", "") == ctypes.c_uint8:
             anon1 = Sliceu8(data=ctypes.cast(anon1, ctypes.POINTER(ctypes.c_uint8)), len=len(anon1))
 
         rval = c_lib.simple_service_lt_return_string_accept_slice(self._ctx, anon1)

--- a/backends/cpython/tests/output/reference_project.py.expected
+++ b/backends/cpython/tests/output/reference_project.py.expected
@@ -319,10 +319,16 @@ def namespaced_type(x: Vec) -> Vec:
 def namespaced_inner_option(x: OptionVec) -> OptionVec:
     return c_lib.namespaced_inner_option(x)
 
-def namespaced_inner_slice(x: SliceVec) -> SliceVec:
+def namespaced_inner_slice(x: SliceVec | ctypes.Array[Vec]) -> SliceVec:
+    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+        x = SliceVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
+
     return c_lib.namespaced_inner_slice(x)
 
-def namespaced_inner_slice_mut(x: SliceMutVec) -> SliceMutVec:
+def namespaced_inner_slice_mut(x: SliceMutVec | ctypes.Array[Vec]) -> SliceMutVec:
+    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+        x = SliceMutVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
+
     return c_lib.namespaced_inner_slice_mut(x)
 
 def panics():
@@ -360,19 +366,34 @@ def pattern_ascii_pointer_len(x: str, y: UseAsciiStringPattern) -> int:
 def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
 
-def pattern_ffi_slice_1(ffi_slice: Sliceu32) -> int:
+def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
+    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == ctypes.c_uint32:
+        ffi_slice = Sliceu32(data=ctypes.cast(ffi_slice, ctypes.POINTER(ctypes.c_uint32)), len=len(ffi_slice))
+
     return c_lib.pattern_ffi_slice_1(ffi_slice)
 
-def pattern_ffi_slice_2(ffi_slice: SliceVec3f32, i: int) -> Vec3f32:
+def pattern_ffi_slice_2(ffi_slice: SliceVec3f32 | ctypes.Array[Vec3f32], i: int) -> Vec3f32:
+    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == Vec3f32:
+        ffi_slice = SliceVec3f32(data=ctypes.cast(ffi_slice, ctypes.POINTER(Vec3f32)), len=len(ffi_slice))
+
     return c_lib.pattern_ffi_slice_2(ffi_slice, i)
 
-def pattern_ffi_slice_3(slice: SliceMutu8, callback):
+def pattern_ffi_slice_3(slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8], callback):
+    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
     if not hasattr(callback, "__ctypes_from_outparam__"):
         callback = callbacks.fn_SliceMutu8(callback)
 
     return c_lib.pattern_ffi_slice_3(slice, callback)
 
-def pattern_ffi_slice_4(slice: Sliceu8, slice2: SliceMutu8):
+def pattern_ffi_slice_4(slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
+    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
+    if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+        slice2 = SliceMutu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
+
     return c_lib.pattern_ffi_slice_4(slice, slice2)
 
 def pattern_ffi_slice_5(slice: ctypes.POINTER(Sliceu8), slice2: ctypes.POINTER(SliceMutu8)):
@@ -1599,32 +1620,53 @@ class SimpleService:
  Multiple lines."""
         return c_lib.simple_service_method_void(self._ctx, )
 
-    def method_mut_self(self, slice: Sliceu8) -> int:
+    def method_mut_self(self, slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self(self._ctx, slice)
 
-    def method_mut_self_void(self, slice: SliceBool):
+    def method_mut_self_void(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """ Single line."""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_void(self._ctx, slice)
 
     def method_mut_self_ref(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8)) -> int:
         """"""
         return c_lib.simple_service_method_mut_self_ref(self._ctx, x, y)
 
-    def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8) -> int:
+    def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_ref_slice(self._ctx, x, y, slice)
 
-    def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8, slice2: Sliceu8) -> int:
+    def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
+        if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+            slice2 = Sliceu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
+
         return c_lib.simple_service_method_mut_self_ref_slice_limited(self._ctx, x, y, slice, slice2)
 
-    def method_mut_self_ffi_error(self, slice: SliceMutu8):
+    def method_mut_self_ffi_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_ffi_error(self._ctx, slice)
 
-    def method_mut_self_no_error(self, slice: SliceMutu8):
+    def method_mut_self_no_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_method_mut_self_no_error(self._ctx, slice)
 
     def return_slice(self, ) -> Sliceu32:
@@ -1676,16 +1718,25 @@ class SimpleServiceLifetime:
 
     def __del__(self):
         c_lib.simple_service_lt_destroy(self._ctx, )
-    def method_lt(self, slice: SliceBool):
+    def method_lt(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_lt_method_lt(self._ctx, slice)
 
-    def method_lt2(self, slice: SliceBool):
+    def method_lt2(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
+        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+            slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
+
         return c_lib.simple_service_lt_method_lt2(self._ctx, slice)
 
-    def return_string_accept_slice(self, anon1: Sliceu8) -> str:
+    def return_string_accept_slice(self, anon1: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> str:
         """"""
+        if hasattr(anon1, "_length_") and hasattr(anon1, "_type_") and getattr(anon1, "_type_") == ctypes.c_uint8:
+            anon1 = Sliceu8(data=ctypes.cast(anon1, ctypes.POINTER(ctypes.c_uint8)), len=len(anon1))
+
         rval = c_lib.simple_service_lt_return_string_accept_slice(self._ctx, anon1)
         return ctypes.string_at(rval)
 

--- a/backends/cpython/tests/output/reference_project.py.expected
+++ b/backends/cpython/tests/output/reference_project.py.expected
@@ -320,13 +320,13 @@ def namespaced_inner_option(x: OptionVec) -> OptionVec:
     return c_lib.namespaced_inner_option(x)
 
 def namespaced_inner_slice(x: SliceVec | ctypes.Array[Vec]) -> SliceVec:
-    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+    if hasattr(x, "_length_") and getattr(x, "_type_", "") == Vec:
         x = SliceVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
 
     return c_lib.namespaced_inner_slice(x)
 
 def namespaced_inner_slice_mut(x: SliceMutVec | ctypes.Array[Vec]) -> SliceMutVec:
-    if hasattr(x, "_length_") and hasattr(x, "_type_") and getattr(x, "_type_") == Vec:
+    if hasattr(x, "_length_") and getattr(x, "_type_", "") == Vec:
         x = SliceMutVec(data=ctypes.cast(x, ctypes.POINTER(Vec)), len=len(x))
 
     return c_lib.namespaced_inner_slice_mut(x)
@@ -367,19 +367,19 @@ def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
 
 def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
-    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == ctypes.c_uint32:
+    if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == ctypes.c_uint32:
         ffi_slice = Sliceu32(data=ctypes.cast(ffi_slice, ctypes.POINTER(ctypes.c_uint32)), len=len(ffi_slice))
 
     return c_lib.pattern_ffi_slice_1(ffi_slice)
 
 def pattern_ffi_slice_2(ffi_slice: SliceVec3f32 | ctypes.Array[Vec3f32], i: int) -> Vec3f32:
-    if hasattr(ffi_slice, "_length_") and hasattr(ffi_slice, "_type_") and getattr(ffi_slice, "_type_") == Vec3f32:
+    if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == Vec3f32:
         ffi_slice = SliceVec3f32(data=ctypes.cast(ffi_slice, ctypes.POINTER(Vec3f32)), len=len(ffi_slice))
 
     return c_lib.pattern_ffi_slice_2(ffi_slice, i)
 
 def pattern_ffi_slice_3(slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8], callback):
-    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+    if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
         slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
     if not hasattr(callback, "__ctypes_from_outparam__"):
@@ -388,10 +388,10 @@ def pattern_ffi_slice_3(slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8], callba
     return c_lib.pattern_ffi_slice_3(slice, callback)
 
 def pattern_ffi_slice_4(slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
-    if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+    if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
         slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
-    if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+    if hasattr(slice2, "_length_") and getattr(slice2, "_type_", "") == ctypes.c_uint8:
         slice2 = SliceMutu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
 
     return c_lib.pattern_ffi_slice_4(slice, slice2)
@@ -1622,14 +1622,14 @@ class SimpleService:
 
     def method_mut_self(self, slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self(self._ctx, slice)
 
     def method_mut_self_void(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """ Single line."""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_void(self._ctx, slice)
@@ -1640,31 +1640,31 @@ class SimpleService:
 
     def method_mut_self_ref_slice(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_ref_slice(self._ctx, x, y, slice)
 
     def method_mut_self_ref_slice_limited(self, x: ctypes.POINTER(ctypes.c_uint8), y: ctypes.POINTER(ctypes.c_uint8), slice: Sliceu8 | ctypes.Array[ctypes.c_uint8], slice2: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> int:
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = Sliceu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
-        if hasattr(slice2, "_length_") and hasattr(slice2, "_type_") and getattr(slice2, "_type_") == ctypes.c_uint8:
+        if hasattr(slice2, "_length_") and getattr(slice2, "_type_", "") == ctypes.c_uint8:
             slice2 = Sliceu8(data=ctypes.cast(slice2, ctypes.POINTER(ctypes.c_uint8)), len=len(slice2))
 
         return c_lib.simple_service_method_mut_self_ref_slice_limited(self._ctx, x, y, slice, slice2)
 
     def method_mut_self_ffi_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_ffi_error(self._ctx, slice)
 
     def method_mut_self_no_error(self, slice: SliceMutu8 | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceMutu8(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_method_mut_self_no_error(self._ctx, slice)
@@ -1720,21 +1720,21 @@ class SimpleServiceLifetime:
         c_lib.simple_service_lt_destroy(self._ctx, )
     def method_lt(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_lt_method_lt(self._ctx, slice)
 
     def method_lt2(self, slice: SliceBool | ctypes.Array[ctypes.c_uint8]):
         """"""
-        if hasattr(slice, "_length_") and hasattr(slice, "_type_") and getattr(slice, "_type_") == ctypes.c_uint8:
+        if hasattr(slice, "_length_") and getattr(slice, "_type_", "") == ctypes.c_uint8:
             slice = SliceBool(data=ctypes.cast(slice, ctypes.POINTER(ctypes.c_uint8)), len=len(slice))
 
         return c_lib.simple_service_lt_method_lt2(self._ctx, slice)
 
     def return_string_accept_slice(self, anon1: Sliceu8 | ctypes.Array[ctypes.c_uint8]) -> str:
         """"""
-        if hasattr(anon1, "_length_") and hasattr(anon1, "_type_") and getattr(anon1, "_type_") == ctypes.c_uint8:
+        if hasattr(anon1, "_length_") and getattr(anon1, "_type_", "") == ctypes.c_uint8:
             anon1 = Sliceu8(data=ctypes.cast(anon1, ctypes.POINTER(ctypes.c_uint8)), len=len(anon1))
 
         rval = c_lib.simple_service_lt_return_string_accept_slice(self._ctx, anon1)

--- a/backends/cpython/tests/output/tests.py
+++ b/backends/cpython/tests/output/tests.py
@@ -121,6 +121,24 @@ class TestFunctions(unittest.TestCase):
 
         self.assertFalse(worked)
 
+    def test_slice_from_ctypes_array(self):
+        array = (ctypes.c_uint32 * 10)()
+        returned_length = r.pattern_ffi_slice_1(array)
+        self.assertEqual(len(array), returned_length)
+
+        slice = r.Sliceu32(data=ctypes.cast(array, ctypes.POINTER(ctypes.c_uint32)), len=len(array))
+        returned_length = r.pattern_ffi_slice_1(slice)
+        self.assertEqual(len(slice), returned_length)
+
+    def test_slice_from_ctypes_array_callback(self):
+        array = (ctypes.c_uint8 * 10)()
+
+        def callback(x):
+            self.assertEqual(1, x[0])
+            self.assertEqual(0, x[1])
+
+        r.pattern_ffi_slice_3(array, callback)
+
 
 class TestPatterns(unittest.TestCase):
 


### PR DESCRIPTION
This change adds the ability to send in a `ctypes.Array` from Python when the parameter is of type `FFISlice` and automatically create a `FFISlice` before function invocation.