### PR TITLE
Respect C# symbol naming in fields for doc writer

### DIFF
--- a/backends/cpython/src/converter.rs
+++ b/backends/cpython/src/converter.rs
@@ -46,9 +46,15 @@ impl Converter {
                 TypePattern::Slice(c) | TypePattern::SliceMut(c) => {
                     let mut res = c.rust_name().to_string();
                     let inner = self.to_ctypes_name(
-                        c.fields().iter().find(|i| i.name().eq_ignore_ascii_case("data"))
-                            .expect("slice must have a data field").the_type().deref_pointer().expect("data must be a pointer type"),
-                        false);
+                        c.fields()
+                            .iter()
+                            .find(|i| i.name().eq_ignore_ascii_case("data"))
+                            .expect("slice must have a data field")
+                            .the_type()
+                            .deref_pointer()
+                            .expect("data must be a pointer type"),
+                        false,
+                    );
                     if is_parameter {
                         res = format!("{} | ctypes.Array[{}]", res, inner);
                     }

--- a/backends/cpython/src/writer.rs
+++ b/backends/cpython/src/writer.rs
@@ -273,20 +273,32 @@ pub trait PythonWriter {
                     TypePattern::AsciiPointer => {
                         indented!(w, [_], r#"if not hasattr({}, "__ctypes_from_outparam__"):"#, arg.name())?;
                         indented!(w, [_ _], r#"{} = ctypes.cast({}, ctypes.POINTER(ctypes.c_char))"#, arg.name(), arg.name())?;
-                    },
+                    }
                     TypePattern::Slice(t) | TypePattern::SliceMut(t) => {
                         let inner = self.converter().to_ctypes_name(
-                            t.fields().iter().find(|i| i.name().eq_ignore_ascii_case("data"))
-                                .expect("slice must have a data field").the_type().deref_pointer().expect("data must be a pointer type"),
-                            false);
+                            t.fields()
+                                .iter()
+                                .find(|i| i.name().eq_ignore_ascii_case("data"))
+                                .expect("slice must have a data field")
+                                .the_type()
+                                .deref_pointer()
+                                .expect("data must be a pointer type"),
+                            false,
+                        );
 
-                        indented!(w, [_], r#"if hasattr({}, "_length_") and getattr({}, "_type_", "") == {}:"#,
-                        arg.name(), arg.name(), inner)?;
+                        indented!(
+                            w,
+                            [_],
+                            r#"if hasattr({}, "_length_") and getattr({}, "_type_", "") == {}:"#,
+                            arg.name(),
+                            arg.name(),
+                            inner
+                        )?;
 
                         indented!(w, [_ _], r#"{} = {}(data=ctypes.cast({}, ctypes.POINTER({})), len=len({}))"#,
                                 arg.name(), arg.the_type().name_within_lib(), arg.name(), inner, arg.name())?;
                         w.newline()?;
-                    },
+                    }
                     _ => {}
                 },
                 _ => {}

--- a/backends/csharp/src/converter.rs
+++ b/backends/csharp/src/converter.rs
@@ -1,4 +1,4 @@
-use heck::ToUpperCamelCase;
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use interoptopus::lang::c::{
     CType, CompositeType, ConstantValue, EnumType, Field, FnPointerType, Function, FunctionSignature, OpaqueType, Parameter, PrimitiveType, PrimitiveValue,
 };
@@ -218,6 +218,14 @@ pub trait CSharpTypeConverter {
             FunctionNameFlavor::RawFFIName => function.name().to_string(),
             FunctionNameFlavor::CSharpMethodNameWithClass => function.name().to_upper_camel_case(),
             FunctionNameFlavor::CSharpMethodNameWithoutClass(class) => function.name().replace(class, "").to_upper_camel_case(),
+        }
+    }
+
+    fn field_name_to_csharp_name(&self, field: &Field, rename_symbols: bool) -> String {
+        if rename_symbols {
+            field.name().to_lower_camel_case()
+        } else {
+            field.name().into()
         }
     }
 }

--- a/backends/csharp/src/docs.rs
+++ b/backends/csharp/src/docs.rs
@@ -156,7 +156,11 @@ impl<'a, W: CSharpWriter> DocGenerator<'a, W> {
         indented!(w, r#"#### Fields "#)?;
         for f in composite.fields() {
             let doc = f.documentation().lines().join("\n");
-            indented!(w, r#"- **{}** - {} "#, f.name(), doc)?;
+            let name = self
+                .csharp_writer
+                .converter()
+                .field_name_to_csharp_name(f, self.csharp_writer.config().rename_symbols);
+            indented!(w, r#"- **{}** - {} "#, name, doc)?;
         }
 
         indented!(w, r#"#### Definition "#)?;

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -1,7 +1,6 @@
 use crate::config::{Config, Unsafe, WriteTypes};
 use crate::converter::{CSharpTypeConverter, Converter, FunctionNameFlavor};
 use crate::overloads::{Helper, OverloadWriter};
-use heck::ToLowerCamelCase;
 use interoptopus::lang::c::{CType, CompositeType, Constant, Documentation, EnumType, Field, FnPointerType, Function, Meta, PrimitiveType, Variant, Visibility};
 use interoptopus::patterns::api_guard::inventory_hash;
 use interoptopus::patterns::callbacks::NamedCallback;
@@ -404,11 +403,7 @@ pub trait CSharpWriter {
                     panic!("Unable to generate bindings for arrays in fields if `unroll_struct_arrays` is not enabled.");
                 }
 
-                let field_name = if self.config().rename_symbols {
-                    field.name().to_lower_camel_case()
-                } else {
-                    field.name().into()
-                };
+                let field_name = self.converter().field_name_to_csharp_name(field, self.config().rename_symbols);
                 let type_name = self.converter().to_typespecifier_in_field(a.array_type(), field, the_type);
                 let visibility = match field.visibility() {
                     Visibility::Public => "public ",
@@ -422,11 +417,7 @@ pub trait CSharpWriter {
                 Ok(())
             }
             _ => {
-                let field_name = if self.config().rename_symbols {
-                    field.name().to_lower_camel_case()
-                } else {
-                    field.name().into()
-                };
+                let field_name = self.converter().field_name_to_csharp_name(field, self.config().rename_symbols);
                 let type_name = self.converter().to_typespecifier_in_field(field.the_type(), field, the_type);
                 let visibility = match field.visibility() {
                     Visibility::Public => "public ",


### PR DESCRIPTION
Previously, the C# doc writer didn't rename fields based on the `rename_symbols` in the C# config. This change fixes that and creates a utility function to get the correct field name.