### PR TITLE
Added ArrayPointer pattern

### DIFF
--- a/backends/c/src/converter.rs
+++ b/backends/c/src/converter.rs
@@ -106,6 +106,7 @@ impl CTypeConverter for Converter {
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(TypePattern::CChar) => "char".to_string(),
             CType::Pattern(TypePattern::NamedCallback(x)) => self.named_callback_to_typename(x),
+            CType::Pattern(TypePattern::ArrayPointer(x)) => format!("{}*", self.to_type_specifier(x)),
             CType::Pattern(x) => self.to_type_specifier(&x.fallback_type()),
             // TODO: This should be handled in nicer way so that arrays-of-arrays and other thing work properly
             CType::Array(_) => panic!("Arrays need special handling in the writer."),

--- a/backends/c/src/writer.rs
+++ b/backends/c/src/writer.rs
@@ -168,6 +168,7 @@ pub trait CWriter {
             CType::ReadWritePointer(_) => {}
             CType::Pattern(p) => match p {
                 TypePattern::AsciiPointer => {}
+                TypePattern::ArrayPointer(_) => {}
                 TypePattern::NamedCallback(e) => {
                     self.write_type_definition_named_callback(w, e)?;
                     w.newline()?;

--- a/backends/c/tests/output_docs_inline/my_header.h
+++ b/backends/c/tests/output_docs_inline/my_header.h
@@ -349,6 +349,8 @@ uint32_t pattern_ascii_pointer_len(const char* x, my_library_use_ascii_string_pa
 
 my_library_slice_use_ascii_string_pattern pattern_ascii_pointer_return_slice();
 
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
+
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 
 my_library_vec3f32 pattern_ffi_slice_2(my_library_slice_vec3f32 ffi_slice, int32_t i);

--- a/backends/c/tests/output_docs_inline/my_header.h
+++ b/backends/c/tests/output_docs_inline/my_header.h
@@ -349,7 +349,7 @@ uint32_t pattern_ascii_pointer_len(const char* x, my_library_use_ascii_string_pa
 
 my_library_slice_use_ascii_string_pattern pattern_ascii_pointer_return_slice();
 
-uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default_value);
 
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 

--- a/backends/c/tests/output_docs_inline/my_header.h.expected
+++ b/backends/c/tests/output_docs_inline/my_header.h.expected
@@ -349,6 +349,8 @@ uint32_t pattern_ascii_pointer_len(const char* x, my_library_use_ascii_string_pa
 
 my_library_slice_use_ascii_string_pattern pattern_ascii_pointer_return_slice();
 
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
+
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 
 my_library_vec3f32 pattern_ffi_slice_2(my_library_slice_vec3f32 ffi_slice, int32_t i);

--- a/backends/c/tests/output_docs_inline/my_header.h.expected
+++ b/backends/c/tests/output_docs_inline/my_header.h.expected
@@ -349,7 +349,7 @@ uint32_t pattern_ascii_pointer_len(const char* x, my_library_use_ascii_string_pa
 
 my_library_slice_use_ascii_string_pattern pattern_ascii_pointer_return_slice();
 
-uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default_value);
 
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 

--- a/backends/c/tests/output_nodocs/my_header.h
+++ b/backends/c/tests/output_nodocs/my_header.h
@@ -276,7 +276,7 @@ uint32_t pattern_ascii_pointer_1(const char* x);
 const char* pattern_ascii_pointer_2();
 uint32_t pattern_ascii_pointer_len(const char* x, my_library_useasciistringpattern y);
 my_library_sliceuseasciistringpattern pattern_ascii_pointer_return_slice();
-uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default_value);
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 my_library_vec3f32 pattern_ffi_slice_2(my_library_slicevec3f32 ffi_slice, int32_t i);
 void pattern_ffi_slice_3(my_library_slicemutu8 slice, my_library_callbackslicemut callback);

--- a/backends/c/tests/output_nodocs/my_header.h
+++ b/backends/c/tests/output_nodocs/my_header.h
@@ -276,6 +276,7 @@ uint32_t pattern_ascii_pointer_1(const char* x);
 const char* pattern_ascii_pointer_2();
 uint32_t pattern_ascii_pointer_len(const char* x, my_library_useasciistringpattern y);
 my_library_sliceuseasciistringpattern pattern_ascii_pointer_return_slice();
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 my_library_vec3f32 pattern_ffi_slice_2(my_library_slicevec3f32 ffi_slice, int32_t i);
 void pattern_ffi_slice_3(my_library_slicemutu8 slice, my_library_callbackslicemut callback);

--- a/backends/c/tests/output_nodocs/my_header.h.expected
+++ b/backends/c/tests/output_nodocs/my_header.h.expected
@@ -276,7 +276,7 @@ uint32_t pattern_ascii_pointer_1(const char* x);
 const char* pattern_ascii_pointer_2();
 uint32_t pattern_ascii_pointer_len(const char* x, my_library_useasciistringpattern y);
 my_library_sliceuseasciistringpattern pattern_ascii_pointer_return_slice();
-uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default_value);
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 my_library_vec3f32 pattern_ffi_slice_2(my_library_slicevec3f32 ffi_slice, int32_t i);
 void pattern_ffi_slice_3(my_library_slicemutu8 slice, my_library_callbackslicemut callback);

--- a/backends/c/tests/output_nodocs/my_header.h.expected
+++ b/backends/c/tests/output_nodocs/my_header.h.expected
@@ -276,6 +276,7 @@ uint32_t pattern_ascii_pointer_1(const char* x);
 const char* pattern_ascii_pointer_2();
 uint32_t pattern_ascii_pointer_len(const char* x, my_library_useasciistringpattern y);
 my_library_sliceuseasciistringpattern pattern_ascii_pointer_return_slice();
+uint32_t pattern_array_pointer_last_or_default(uint32_t* ptr, uint64_t len, uint32_t default);
 uint32_t pattern_ffi_slice_1(my_library_sliceu32 ffi_slice);
 my_library_vec3f32 pattern_ffi_slice_2(my_library_slicevec3f32 ffi_slice, int32_t i);
 void pattern_ffi_slice_3(my_library_slicemutu8 slice, my_library_callbackslicemut callback);

--- a/backends/cpython/src/converter.rs
+++ b/backends/cpython/src/converter.rs
@@ -101,6 +101,7 @@ impl Converter {
             CType::Pattern(pattern) => match pattern {
                 TypePattern::AsciiPointer => self.to_ctypes_name(&pattern.fallback_type(), with_type_annotations),
                 TypePattern::APIVersion => "ctypes.c_uint64".to_string(),
+                TypePattern::ArrayPointer(_) => "ctypes.c_void_p".to_string(),
                 TypePattern::FFIErrorEnum(_) => "ctypes.c_int".to_string(),
                 TypePattern::Slice(c) => c.rust_name().to_string(),
                 TypePattern::SliceMut(c) => c.rust_name().to_string(),

--- a/backends/cpython/tests/output/reference_project.md
+++ b/backends/cpython/tests/output/reference_project.md
@@ -52,6 +52,7 @@ Freestanding callables inside the module.
  - **[pattern_ascii_pointer_2](#pattern_ascii_pointer_2)** - 
  - **[pattern_ascii_pointer_len](#pattern_ascii_pointer_len)** - 
  - **[pattern_ascii_pointer_return_slice](#pattern_ascii_pointer_return_slice)** - 
+ - **[pattern_array_pointer_last_or_default](#pattern_array_pointer_last_or_default)** - 
  - **[pattern_ffi_slice_1](#pattern_ffi_slice_1)** - 
  - **[pattern_ffi_slice_2](#pattern_ffi_slice_2)** - 
  - **[pattern_ffi_slice_3](#pattern_ffi_slice_3)** - 
@@ -1221,6 +1222,15 @@ def pattern_ascii_pointer_len(x: str, y: UseAsciiStringPattern) -> int:
 #### Definition 
 ```python
 def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
+    ...
+```
+
+---
+
+## pattern_array_pointer_last_or_default 
+#### Definition 
+```python
+def pattern_array_pointer_last_or_default(ptr, len: int, default: int) -> int:
     ...
 ```
 

--- a/backends/cpython/tests/output/reference_project.md
+++ b/backends/cpython/tests/output/reference_project.md
@@ -1230,7 +1230,7 @@ def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
 ## pattern_array_pointer_last_or_default 
 #### Definition 
 ```python
-def pattern_array_pointer_last_or_default(ptr, len: int, default: int) -> int:
+def pattern_array_pointer_last_or_default(ptr, len: int, default_value: int) -> int:
     ...
 ```
 

--- a/backends/cpython/tests/output/reference_project.py
+++ b/backends/cpython/tests/output/reference_project.py
@@ -368,8 +368,8 @@ def pattern_ascii_pointer_len(x: str, y: UseAsciiStringPattern) -> int:
 def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
 
-def pattern_array_pointer_last_or_default(ptr, len: int, default: int) -> int:
-    return c_lib.pattern_array_pointer_last_or_default(ptr, len, default)
+def pattern_array_pointer_last_or_default(ptr, len: int, default_value: int) -> int:
+    return c_lib.pattern_array_pointer_last_or_default(ptr, len, default_value)
 
 def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
     if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == ctypes.c_uint32:

--- a/backends/cpython/tests/output/reference_project.py
+++ b/backends/cpython/tests/output/reference_project.py
@@ -59,6 +59,7 @@ def init_lib(path):
     c_lib.pattern_ascii_pointer_2.argtypes = []
     c_lib.pattern_ascii_pointer_len.argtypes = [ctypes.POINTER(ctypes.c_char), UseAsciiStringPattern]
     c_lib.pattern_ascii_pointer_return_slice.argtypes = []
+    c_lib.pattern_array_pointer_last_or_default.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint32]
     c_lib.pattern_ffi_slice_1.argtypes = [Sliceu32]
     c_lib.pattern_ffi_slice_2.argtypes = [SliceVec3f32, ctypes.c_int32]
     c_lib.pattern_ffi_slice_3.argtypes = [SliceMutu8, callbacks.fn_SliceMutu8]
@@ -148,6 +149,7 @@ def init_lib(path):
     c_lib.pattern_ascii_pointer_2.restype = ctypes.POINTER(ctypes.c_char)
     c_lib.pattern_ascii_pointer_len.restype = ctypes.c_uint32
     c_lib.pattern_ascii_pointer_return_slice.restype = SliceUseAsciiStringPattern
+    c_lib.pattern_array_pointer_last_or_default.restype = ctypes.c_uint32
     c_lib.pattern_ffi_slice_1.restype = ctypes.c_uint32
     c_lib.pattern_ffi_slice_2.restype = Vec3f32
     c_lib.pattern_ffi_slice_delegate.restype = ctypes.c_uint8
@@ -365,6 +367,9 @@ def pattern_ascii_pointer_len(x: str, y: UseAsciiStringPattern) -> int:
 
 def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
+
+def pattern_array_pointer_last_or_default(ptr, len: int, default: int) -> int:
+    return c_lib.pattern_array_pointer_last_or_default(ptr, len, default)
 
 def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
     if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == ctypes.c_uint32:

--- a/backends/cpython/tests/output/reference_project.py.expected
+++ b/backends/cpython/tests/output/reference_project.py.expected
@@ -368,8 +368,8 @@ def pattern_ascii_pointer_len(x: str, y: UseAsciiStringPattern) -> int:
 def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
 
-def pattern_array_pointer_last_or_default(ptr, len: int, default: int) -> int:
-    return c_lib.pattern_array_pointer_last_or_default(ptr, len, default)
+def pattern_array_pointer_last_or_default(ptr, len: int, default_value: int) -> int:
+    return c_lib.pattern_array_pointer_last_or_default(ptr, len, default_value)
 
 def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
     if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == ctypes.c_uint32:

--- a/backends/cpython/tests/output/reference_project.py.expected
+++ b/backends/cpython/tests/output/reference_project.py.expected
@@ -59,6 +59,7 @@ def init_lib(path):
     c_lib.pattern_ascii_pointer_2.argtypes = []
     c_lib.pattern_ascii_pointer_len.argtypes = [ctypes.POINTER(ctypes.c_char), UseAsciiStringPattern]
     c_lib.pattern_ascii_pointer_return_slice.argtypes = []
+    c_lib.pattern_array_pointer_last_or_default.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint32]
     c_lib.pattern_ffi_slice_1.argtypes = [Sliceu32]
     c_lib.pattern_ffi_slice_2.argtypes = [SliceVec3f32, ctypes.c_int32]
     c_lib.pattern_ffi_slice_3.argtypes = [SliceMutu8, callbacks.fn_SliceMutu8]
@@ -148,6 +149,7 @@ def init_lib(path):
     c_lib.pattern_ascii_pointer_2.restype = ctypes.POINTER(ctypes.c_char)
     c_lib.pattern_ascii_pointer_len.restype = ctypes.c_uint32
     c_lib.pattern_ascii_pointer_return_slice.restype = SliceUseAsciiStringPattern
+    c_lib.pattern_array_pointer_last_or_default.restype = ctypes.c_uint32
     c_lib.pattern_ffi_slice_1.restype = ctypes.c_uint32
     c_lib.pattern_ffi_slice_2.restype = Vec3f32
     c_lib.pattern_ffi_slice_delegate.restype = ctypes.c_uint8
@@ -365,6 +367,9 @@ def pattern_ascii_pointer_len(x: str, y: UseAsciiStringPattern) -> int:
 
 def pattern_ascii_pointer_return_slice() -> SliceUseAsciiStringPattern:
     return c_lib.pattern_ascii_pointer_return_slice()
+
+def pattern_array_pointer_last_or_default(ptr, len: int, default: int) -> int:
+    return c_lib.pattern_array_pointer_last_or_default(ptr, len, default)
 
 def pattern_ffi_slice_1(ffi_slice: Sliceu32 | ctypes.Array[ctypes.c_uint32]) -> int:
     if hasattr(ffi_slice, "_length_") and getattr(ffi_slice, "_type_", "") == ctypes.c_uint32:

--- a/backends/csharp/benches/Interop.cs
+++ b/backends/csharp/benches/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5253872074049475639ul)
+            if (api_version != 5662904782213269495ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5253872074049475639). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -248,6 +248,9 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/benches/Interop.cs
+++ b/backends/csharp/benches/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5662904782213269495ul)
+            if (api_version != 6553690408439348842ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (6553690408439348842). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -250,7 +250,7 @@ namespace My.Company
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
-        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/src/converter.rs
+++ b/backends/csharp/src/converter.rs
@@ -68,6 +68,7 @@ pub trait CSharpTypeConverter {
             CType::Pattern(x) => match x {
                 TypePattern::AsciiPointer => false,
                 TypePattern::APIVersion => true,
+                TypePattern::ArrayPointer(_) => true,
                 TypePattern::FFIErrorEnum(_) => true,
                 TypePattern::Slice(_) => false,
                 TypePattern::SliceMut(_) => false,
@@ -107,6 +108,7 @@ pub trait CSharpTypeConverter {
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(x) => match x {
                 TypePattern::AsciiPointer => "string".to_string(),
+                TypePattern::ArrayPointer(_) => "IntPtr".to_string(),
                 TypePattern::FFIErrorEnum(e) => self.enum_to_typename(e.the_enum()),
                 TypePattern::Slice(e) => self.composite_to_typename(e),
                 TypePattern::SliceMut(e) => self.composite_to_typename(e),
@@ -150,6 +152,7 @@ pub trait CSharpTypeConverter {
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(x) => match x {
                 TypePattern::AsciiPointer => "string".to_string(),
+                TypePattern::ArrayPointer(_) => "IntPtr".to_string(),
                 TypePattern::FFIErrorEnum(e) => self.enum_to_typename(e.the_enum()),
                 TypePattern::Slice(x) => self.composite_to_typename(x),
                 TypePattern::SliceMut(x) => self.composite_to_typename(x),
@@ -174,6 +177,7 @@ pub trait CSharpTypeConverter {
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(x) => match x {
                 TypePattern::AsciiPointer => "IntPtr".to_string(),
+                TypePattern::ArrayPointer(_) => "IntPtr".to_string(),
                 TypePattern::FFIErrorEnum(e) => self.enum_to_typename(e.the_enum()),
                 TypePattern::Slice(x) => self.composite_to_typename(x),
                 TypePattern::SliceMut(x) => self.composite_to_typename(x),

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -222,6 +222,7 @@ pub trait CSharpWriter {
             CType::ReadWritePointer(_) => {}
             CType::Pattern(x) => match x {
                 TypePattern::AsciiPointer => {}
+                TypePattern::ArrayPointer(_) => {}
                 TypePattern::FFIErrorEnum(e) => {
                     self.write_type_definition_enum(w, e.the_enum(), WriteFor::Code)?;
                     w.newline()?;
@@ -505,6 +506,7 @@ pub trait CSharpWriter {
             CType::Pattern(x) => match x {
                 TypePattern::AsciiPointer => true,
                 TypePattern::APIVersion => true,
+                TypePattern::ArrayPointer(_) => true,
                 TypePattern::FFIErrorEnum(x) => self.should_emit_by_meta(x.the_enum().meta()),
                 TypePattern::Slice(x) => self.should_emit_by_meta(x.meta()),
                 TypePattern::SliceMut(x) => self.should_emit_by_meta(x.meta()),

--- a/backends/csharp/tests/output/reference_project.md
+++ b/backends/csharp/tests/output/reference_project.md
@@ -52,6 +52,7 @@ Freestanding callables inside the module.
  - **[pattern_ascii_pointer_2](#pattern_ascii_pointer_2)** - 
  - **[pattern_ascii_pointer_len](#pattern_ascii_pointer_len)** - 
  - **[pattern_ascii_pointer_return_slice](#pattern_ascii_pointer_return_slice)** - 
+ - **[pattern_array_pointer_last_or_default](#pattern_array_pointer_last_or_default)** - 
  - **[pattern_ffi_slice_1](#pattern_ffi_slice_1)** - 
  - **[pattern_ffi_slice_2](#pattern_ffi_slice_2)** - 
  - **[pattern_ffi_slice_3](#pattern_ffi_slice_3)** - 
@@ -1102,6 +1103,14 @@ public static extern uint pattern_ascii_pointer_len(string x, UseAsciiStringPatt
 #### Definition 
 ```csharp
 public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+```
+
+---
+
+### <a name="pattern_array_pointer_last_or_default">**pattern_array_pointer_last_or_default**</a>
+#### Definition 
+```csharp
+public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 ```
 
 ---

--- a/backends/csharp/tests/output/reference_project.md
+++ b/backends/csharp/tests/output/reference_project.md
@@ -1110,7 +1110,7 @@ public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_sli
 ### <a name="pattern_array_pointer_last_or_default">**pattern_array_pointer_last_or_default**</a>
 #### Definition 
 ```csharp
-public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 ```
 
 ---

--- a/backends/csharp/tests/output_safe/Interop.cs
+++ b/backends/csharp/tests/output_safe/Interop.cs
@@ -18,9 +18,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5253872074049475639ul)
+            if (api_version != 5662904782213269495ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5253872074049475639). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -227,6 +227,9 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_safe/Interop.cs
+++ b/backends/csharp/tests/output_safe/Interop.cs
@@ -18,9 +18,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5662904782213269495ul)
+            if (api_version != 6553690408439348842ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (6553690408439348842). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -229,7 +229,7 @@ namespace My.Company
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
-        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_safe/Interop.cs.expected
+++ b/backends/csharp/tests/output_safe/Interop.cs.expected
@@ -18,9 +18,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5253872074049475639ul)
+            if (api_version != 5662904782213269495ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5253872074049475639). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -227,6 +227,9 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_safe/Interop.cs.expected
+++ b/backends/csharp/tests/output_safe/Interop.cs.expected
@@ -18,9 +18,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5662904782213269495ul)
+            if (api_version != 6553690408439348842ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (6553690408439348842). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -229,7 +229,7 @@ namespace My.Company
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
-        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5253872074049475639ul)
+            if (api_version != 5662904782213269495ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5253872074049475639). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -248,6 +248,9 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5662904782213269495ul)
+            if (api_version != 6553690408439348842ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (6553690408439348842). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -250,7 +250,7 @@ namespace My.Company
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
-        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5253872074049475639ul)
+            if (api_version != 5662904782213269495ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5253872074049475639). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -248,6 +248,9 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5662904782213269495ul)
+            if (api_version != 6553690408439348842ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (6553690408439348842). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -250,7 +250,7 @@ namespace My.Company
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
-        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unsafe/Interop.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5253872074049475639ul)
+            if (api_version != 5662904782213269495ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5253872074049475639). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -248,6 +248,9 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unsafe/Interop.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.cs
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5662904782213269495ul)
+            if (api_version != 6553690408439348842ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (6553690408439348842). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -250,7 +250,7 @@ namespace My.Company
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
-        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unsafe/Interop.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.cs.expected
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5253872074049475639ul)
+            if (api_version != 5662904782213269495ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5253872074049475639). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -248,6 +248,9 @@ namespace My.Company
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ascii_pointer_return_slice")]
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/backends/csharp/tests/output_unsafe/Interop.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.cs.expected
@@ -23,9 +23,9 @@ namespace My.Company
         static Interop()
         {
             var api_version = Interop.pattern_api_guard();
-            if (api_version != 5662904782213269495ul)
+            if (api_version != 6553690408439348842ul)
             {
-                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (5662904782213269495). You probably forgot to update / copy either the bindings or the library.");
+                throw new TypeLoadException($"API reports hash {api_version} which differs from hash in bindings (6553690408439348842). You probably forgot to update / copy either the bindings or the library.");
             }
         }
 
@@ -250,7 +250,7 @@ namespace My.Company
         public static extern SliceUseAsciiStringPattern pattern_ascii_pointer_return_slice();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_array_pointer_last_or_default")]
-        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default);
+        public static extern uint pattern_array_pointer_last_or_default(IntPtr ptr, ulong len, uint default_value);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "pattern_ffi_slice_1")]
         public static extern uint pattern_ffi_slice_1(Sliceu32 ffi_slice);

--- a/core/src/patterns/array_ptr.rs
+++ b/core/src/patterns/array_ptr.rs
@@ -3,7 +3,7 @@ use crate::lang::rust::CTypeInfo;
 use crate::patterns::TypePattern;
 use std::marker::PhantomData;
 
-#[repr(C)]
+#[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize))]
 #[cfg_attr(not(feature = "serde"), derive(Debug, Copy, Clone, PartialEq))]
 pub struct ArrayPointer<'a, T> {
@@ -31,16 +31,15 @@ where
 }
 
 impl<'a, T> ArrayPointer<'a, T> {
-    pub fn as_slice<'b>(&'b self, len: u64) -> &'b [T]
+    pub unsafe fn as_slice<'b>(&'b self, len: u64) -> &'b [T]
     where
         'a: 'b,
     {
         if self.data.is_null() {
             &[]
         } else {
-            // If non-null this should always point to valid data and the lifetime should be
-            // guaranteed via the struct <'a>.
-            unsafe { std::slice::from_raw_parts(self.data, len as usize) }
+            // Dependent on user passing in the correct length, hence function marked as unsafe
+            std::slice::from_raw_parts(self.data, len as usize)
         }
     }
 }

--- a/core/src/patterns/array_ptr.rs
+++ b/core/src/patterns/array_ptr.rs
@@ -1,0 +1,46 @@
+use crate::lang::c::CType;
+use crate::lang::rust::CTypeInfo;
+use crate::patterns::TypePattern;
+use std::marker::PhantomData;
+
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize))]
+#[cfg_attr(not(feature = "serde"), derive(Debug, Copy, Clone, PartialEq))]
+pub struct ArrayPointer<'a, T> {
+    data: *const T,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> Default for ArrayPointer<'a, T> {
+    fn default() -> Self {
+        ArrayPointer {
+            data: std::ptr::null(),
+            _phantom: PhantomData::default(),
+        }
+    }
+}
+
+unsafe impl<'a, T> CTypeInfo for ArrayPointer<'a, T>
+where
+    T: CTypeInfo,
+{
+    #[rustfmt::skip]
+    fn type_info() -> CType {
+        CType::Pattern(TypePattern::ArrayPointer(Box::new(T::type_info())))
+    }
+}
+
+impl<'a, T> ArrayPointer<'a, T> {
+    pub fn as_slice<'b>(&'b self, len: u64) -> &'b [T]
+    where
+        'a: 'b,
+    {
+        if self.data.is_null() {
+            &[]
+        } else {
+            // If non-null this should always point to valid data and the lifetime should be
+            // guaranteed via the struct <'a>.
+            unsafe { std::slice::from_raw_parts(self.data, len as usize) }
+        }
+    }
+}

--- a/core/src/patterns/mod.rs
+++ b/core/src/patterns/mod.rs
@@ -78,6 +78,7 @@ use crate::patterns::service::Service;
 #[doc(hidden)]
 pub mod api_entry;
 pub mod api_guard;
+pub mod array_ptr;
 pub mod callbacks;
 pub mod option;
 pub mod primitives;
@@ -85,6 +86,7 @@ pub mod result;
 pub mod service;
 pub mod slice;
 pub mod string;
+
 
 /// A pattern on a library level, usually involving both methods and types.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -109,6 +111,7 @@ impl From<Service> for LibraryPattern {
 pub enum TypePattern {
     AsciiPointer,
     APIVersion,
+    ArrayPointer(Box<CType>),
     FFIErrorEnum(FFIErrorEnum),
     Slice(CompositeType),
     SliceMut(CompositeType),
@@ -126,6 +129,7 @@ impl TypePattern {
     pub fn fallback_type(&self) -> CType {
         match self {
             TypePattern::AsciiPointer => CType::ReadPointer(Box::new(CType::Pattern(TypePattern::CChar))),
+            TypePattern::ArrayPointer(x) => CType::ReadPointer(x.clone()),
             TypePattern::FFIErrorEnum(e) => CType::Enum(e.the_enum().clone()),
             TypePattern::Slice(x) => CType::Composite(x.clone()),
             TypePattern::SliceMut(x) => CType::Composite(x.clone()),

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -156,6 +156,7 @@ pub(crate) fn ctypes_from_type_recursive(start: &CType, types: &mut HashSet<CTyp
         // types; which we need to recursively inspect.
         CType::Pattern(x) => match x {
             TypePattern::AsciiPointer => {}
+            TypePattern::ArrayPointer(inner) => ctypes_from_type_recursive(inner, types),
             TypePattern::FFIErrorEnum(_) => {}
             TypePattern::NamedCallback(x) => {
                 let inner = x.fnpointer();
@@ -208,6 +209,7 @@ pub(crate) fn extract_namespaces_from_types(types: &[CType], into: &mut HashSet<
             CType::Pattern(x) => match x {
                 TypePattern::AsciiPointer => {}
                 TypePattern::APIVersion => {}
+                TypePattern::ArrayPointer(_) => {}
                 TypePattern::FFIErrorEnum(x) => {
                     into.insert(x.the_enum().meta().namespace().to_string());
                 }
@@ -311,6 +313,7 @@ pub fn is_global_type(t: &CType) -> bool {
         CType::Pattern(x) => match x {
             TypePattern::AsciiPointer => true,
             TypePattern::APIVersion => false,
+            TypePattern::ArrayPointer(x) => is_global_type(x),
             TypePattern::FFIErrorEnum(_) => false,
             TypePattern::Slice(x) => x.fields().iter().all(|x| is_global_type(x.the_type())),
             TypePattern::SliceMut(x) => x.fields().iter().all(|x| is_global_type(x.the_type())),

--- a/reference_project/src/lib.rs
+++ b/reference_project/src/lib.rs
@@ -15,6 +15,7 @@ pub mod functions;
 pub mod patterns {
     // pub mod api_entry;
     pub mod api_guard;
+    pub mod array_pointer;
     pub mod ascii_pointer;
     pub mod callbacks;
     pub mod option;
@@ -78,6 +79,7 @@ pub fn ffi_inventory() -> Inventory {
             .register(function!(patterns::ascii_pointer::pattern_ascii_pointer_2))
             .register(function!(patterns::ascii_pointer::pattern_ascii_pointer_len))
             .register(function!(patterns::ascii_pointer::pattern_ascii_pointer_return_slice))
+            .register(function!(patterns::array_pointer::pattern_array_pointer_last_or_default))
             .register(function!(patterns::slice::pattern_ffi_slice_1))
             .register(function!(patterns::slice::pattern_ffi_slice_2))
             .register(function!(patterns::slice::pattern_ffi_slice_3))

--- a/reference_project/src/patterns/array_pointer.rs
+++ b/reference_project/src/patterns/array_pointer.rs
@@ -3,6 +3,6 @@ use interoptopus::patterns::array_ptr::ArrayPointer;
 
 #[ffi_function]
 #[no_mangle]
-pub extern "C" fn pattern_array_pointer_last_or_default(ptr: ArrayPointer<u32>, len: u64, default: u32) -> u32 {
-    ptr.as_slice(len).last().cloned().unwrap_or(default)
+pub extern "C" fn pattern_array_pointer_last_or_default(ptr: ArrayPointer<u32>, len: u64, default_value: u32) -> u32 {
+    ptr.as_slice(len).last().cloned().unwrap_or(default_value)
 }

--- a/reference_project/src/patterns/array_pointer.rs
+++ b/reference_project/src/patterns/array_pointer.rs
@@ -1,0 +1,8 @@
+use interoptopus::ffi_function;
+use interoptopus::patterns::array_ptr::ArrayPointer;
+
+#[ffi_function]
+#[no_mangle]
+pub extern "C" fn pattern_array_pointer_last_or_default(ptr: ArrayPointer<u32>, len: u64, default: u32) -> u32 {
+    ptr.as_slice(len).last().cloned().unwrap_or(default)
+}

--- a/reference_project/src/patterns/array_pointer.rs
+++ b/reference_project/src/patterns/array_pointer.rs
@@ -4,5 +4,5 @@ use interoptopus::patterns::array_ptr::ArrayPointer;
 #[ffi_function]
 #[no_mangle]
 pub extern "C" fn pattern_array_pointer_last_or_default(ptr: ArrayPointer<u32>, len: u64, default_value: u32) -> u32 {
-    ptr.as_slice(len).last().cloned().unwrap_or(default_value)
+    unsafe { ptr.as_slice(len).last().cloned().unwrap_or(default_value) }
 }


### PR DESCRIPTION
Added an ArrayPointer pattern. This is a lighter-weight alternative to the FFISlice pattern which allows expression of a pointer to an array of a type. This allows backends to generate more relevant bindings. Crucially, it forces the C# backend to declare the parameter as an `IntPtr` rather than a `ref T` (which makes little sense for an array of values).