### PR TITLE
C# backend - generate ref params even for *mut _

### DIFF
--- a/backends/csharp/benches/Interop.cs
+++ b/backends/csharp/benches/Interop.cs
@@ -82,7 +82,7 @@ namespace My.Company
         ///
         /// Parameter x must point to valid data.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
-        public static extern IntPtr ptr_mut(out long x);
+        public static extern IntPtr ptr_mut(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
@@ -91,13 +91,13 @@ namespace My.Company
         public static extern IntPtr ref_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
-        public static extern IntPtr ref_mut_simple(out long x);
+        public static extern IntPtr ref_mut_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
-        public static extern bool ref_mut_option(out long x);
+        public static extern bool ref_mut_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
@@ -624,35 +624,35 @@ namespace My.Company
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
-        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
+        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, ref byte y);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
-        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
+        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, Sliceu8 slice);
 
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, byte[] slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, byte[] slice)
         {
             unsafe
             {
                 fixed (void* ptr_slice = slice)
                 {
                     var slice_slice = new Sliceu8(new IntPtr(ptr_slice), (ulong) slice.Length);
-                    return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+                    return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice)
         {
             var slice_slice = new Sliceu8(slice);
-            return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+            return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
         }
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice_limited")]
-        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
+        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
 
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
             unsafe
             {
@@ -662,18 +662,18 @@ namespace My.Company
                     fixed (void* ptr_slice2 = slice2)
                     {
                         var slice2_slice = new Sliceu8(new IntPtr(ptr_slice2), (ulong) slice2.Length);
-                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
                     }
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
             var slice_slice = new Sliceu8(slice);
             var slice2_slice = new Sliceu8(slice2);
-            return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+            return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
         }
         #endif
 
@@ -1449,42 +1449,42 @@ namespace My.Company
         }
         #endif
 
-        public byte MethodMutSelfRef(ref byte x, out byte y)
+        public byte MethodMutSelfRef(ref byte x, ref byte y)
         {
-            return Interop.simple_service_method_mut_self_ref(_context, ref x, out y);
+            return Interop.simple_service_method_mut_self_ref(_context, ref x, ref y);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, NativeArray<byte> slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, NativeArray<byte> slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
         #endif
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
         #endif
 

--- a/backends/csharp/src/config.rs
+++ b/backends/csharp/src/config.rs
@@ -93,6 +93,8 @@ pub struct Config {
     pub use_unsafe: Unsafe,
     /// Generate functions and field names matching C# conventions, instead of mapping them 1:1 with Rust.
     pub rename_symbols: bool,
+    /// Generate bindings with [SuppressUnmanagedCodeSecurity] attribute
+    pub suppress_unmanaged_code_security: bool,
     /// Also generate markers for easier debugging
     pub debug: bool,
 }
@@ -113,6 +115,7 @@ impl Default for Config {
             write_types: WriteTypes::NamespaceAndInteroptopusGlobal,
             use_unsafe: Unsafe::None,
             rename_symbols: false,
+            suppress_unmanaged_code_security: false,
             debug: false,
         }
     }

--- a/backends/csharp/src/converter.rs
+++ b/backends/csharp/src/converter.rs
@@ -145,7 +145,7 @@ pub trait CSharpTypeConverter {
                 CType::Pattern(TypePattern::CChar) => "IntPtr".to_string(),
                 CType::Pattern(TypePattern::Slice(_)) => format!("ref {}", self.to_typespecifier_in_param(z)),
                 CType::Pattern(TypePattern::SliceMut(_)) => format!("ref {}", self.to_typespecifier_in_param(z)),
-                _ => format!("out {}", self.to_typespecifier_in_param(z)),
+                _ => format!("ref {}", self.to_typespecifier_in_param(z)),
             },
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(x) => match x {

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -50,6 +50,10 @@ pub trait CSharpWriter {
         indented!(w, r#"using System.Collections;"#)?;
         indented!(w, r#"using System.Collections.Generic;"#)?;
         indented!(w, r#"using System.Runtime.InteropServices;"#)?;
+        
+        if self.config().suppress_unmanaged_code_security {
+            indented!(w, r#"using System.Security;"#)?;
+        }
 
         for overload in self.overloads() {
             overload.write_imports(w, self.helper())?;
@@ -165,7 +169,13 @@ pub trait CSharpWriter {
             w,
             r#"[DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "{}")]"#,
             function.name()
-        )
+        )?;
+
+        if self.config().suppress_unmanaged_code_security {
+            indented!(w, r#"[SuppressUnmanagedCodeSecurity]"#)?;
+        }
+
+        Ok(())
     }
 
     fn write_function_declaration(&self, w: &mut IndentWriter, function: &Function) -> Result<(), Error> {
@@ -316,7 +326,13 @@ pub trait CSharpWriter {
     }
 
     fn write_type_definition_fn_pointer_annotation(&self, w: &mut IndentWriter, _the_type: &FnPointerType) -> Result<(), Error> {
-        indented!(w, r#"[UnmanagedFunctionPointer(CallingConvention.Cdecl)]"#)
+        indented!(w, r#"[UnmanagedFunctionPointer(CallingConvention.Cdecl)]"#)?;
+
+        if self.config().suppress_unmanaged_code_security {
+            indented!(w, r#"[SuppressUnmanagedCodeSecurity]"#)?;
+        }
+
+        Ok(())
     }
 
     fn write_type_definition_fn_pointer_body(&self, w: &mut IndentWriter, the_type: &FnPointerType) -> Result<(), Error> {

--- a/backends/csharp/tests/output/reference_project.md
+++ b/backends/csharp/tests/output/reference_project.md
@@ -818,7 +818,7 @@ public static extern IntPtr ptr(ref long x);
 Parameter x must point to valid data.
 #### Definition 
 ```csharp
-public static extern IntPtr ptr_mut(out long x);
+public static extern IntPtr ptr_mut(ref long x);
 ```
 
 ---
@@ -842,7 +842,7 @@ public static extern IntPtr ref_simple(ref long x);
 ### <a name="ref_mut_simple">**ref_mut_simple**</a>
 #### Definition 
 ```csharp
-public static extern IntPtr ref_mut_simple(out long x);
+public static extern IntPtr ref_mut_simple(ref long x);
 ```
 
 ---
@@ -858,7 +858,7 @@ public static extern bool ref_option(ref long x);
 ### <a name="ref_mut_option">**ref_mut_option**</a>
 #### Definition 
 ```csharp
-public static extern bool ref_mut_option(out long x);
+public static extern bool ref_mut_option(ref long x);
 ```
 
 ---
@@ -1399,7 +1399,7 @@ public class SimpleService {
 #### Definition 
 ```csharp
 public class SimpleService {
-    public byte MethodMutSelfRef(ref byte x, out byte y);
+    public byte MethodMutSelfRef(ref byte x, ref byte y);
 }
 ```
 
@@ -1410,10 +1410,10 @@ public class SimpleService {
 #### Definition 
 ```csharp
 public class SimpleService {
-    public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice);
-    public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice);
+    public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice);
+    public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice);
 #if UNITY_2018_1_OR_NEWER
-    public byte MethodMutSelfRefSlice(ref byte x, out byte y, NativeArray<byte> slice);
+    public byte MethodMutSelfRefSlice(ref byte x, ref byte y, NativeArray<byte> slice);
 #endif
 }
 ```
@@ -1425,10 +1425,10 @@ public class SimpleService {
 #### Definition 
 ```csharp
 public class SimpleService {
-    public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
-    public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2);
+    public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
+    public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2);
 #if UNITY_2018_1_OR_NEWER
-    public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2);
+    public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2);
 #endif
 }
 ```

--- a/backends/csharp/tests/output_safe/Interop.cs
+++ b/backends/csharp/tests/output_safe/Interop.cs
@@ -77,7 +77,7 @@ namespace My.Company
         ///
         /// Parameter x must point to valid data.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
-        public static extern IntPtr ptr_mut(out long x);
+        public static extern IntPtr ptr_mut(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
@@ -86,13 +86,13 @@ namespace My.Company
         public static extern IntPtr ref_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
-        public static extern IntPtr ref_mut_simple(out long x);
+        public static extern IntPtr ref_mut_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
-        public static extern bool ref_mut_option(out long x);
+        public static extern bool ref_mut_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
@@ -522,18 +522,18 @@ namespace My.Company
         }
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
-        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
+        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, ref byte y);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
-        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
+        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, Sliceu8 slice);
 
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, byte[] slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, byte[] slice)
         {
             var slice_pinned = GCHandle.Alloc(slice, GCHandleType.Pinned);
             var slice_slice = new Sliceu8(slice_pinned, (ulong) slice.Length);
             try
             {
-                return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+                return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
             }
             finally
             {
@@ -542,9 +542,9 @@ namespace My.Company
         }
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice_limited")]
-        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
+        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
 
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
             var slice_pinned = GCHandle.Alloc(slice, GCHandleType.Pinned);
             var slice_slice = new Sliceu8(slice_pinned, (ulong) slice.Length);
@@ -552,7 +552,7 @@ namespace My.Company
             var slice2_slice = new Sliceu8(slice2_pinned, (ulong) slice2.Length);
             try
             {
-                return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+                return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
             }
             finally
             {
@@ -1201,29 +1201,29 @@ namespace My.Company
             Interop.simple_service_method_mut_self_void(_context, slice);
         }
 
-        public byte MethodMutSelfRef(ref byte x, out byte y)
+        public byte MethodMutSelfRef(ref byte x, ref byte y)
         {
-            return Interop.simple_service_method_mut_self_ref(_context, ref x, out y);
+            return Interop.simple_service_method_mut_self_ref(_context, ref x, ref y);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
         public void MethodMutSelfFfiError(SliceMutu8 slice)

--- a/backends/csharp/tests/output_safe/Interop.cs.expected
+++ b/backends/csharp/tests/output_safe/Interop.cs.expected
@@ -77,7 +77,7 @@ namespace My.Company
         ///
         /// Parameter x must point to valid data.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
-        public static extern IntPtr ptr_mut(out long x);
+        public static extern IntPtr ptr_mut(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
@@ -86,13 +86,13 @@ namespace My.Company
         public static extern IntPtr ref_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
-        public static extern IntPtr ref_mut_simple(out long x);
+        public static extern IntPtr ref_mut_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
-        public static extern bool ref_mut_option(out long x);
+        public static extern bool ref_mut_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
@@ -522,18 +522,18 @@ namespace My.Company
         }
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
-        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
+        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, ref byte y);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
-        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
+        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, Sliceu8 slice);
 
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, byte[] slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, byte[] slice)
         {
             var slice_pinned = GCHandle.Alloc(slice, GCHandleType.Pinned);
             var slice_slice = new Sliceu8(slice_pinned, (ulong) slice.Length);
             try
             {
-                return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+                return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
             }
             finally
             {
@@ -542,9 +542,9 @@ namespace My.Company
         }
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice_limited")]
-        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
+        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
 
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
             var slice_pinned = GCHandle.Alloc(slice, GCHandleType.Pinned);
             var slice_slice = new Sliceu8(slice_pinned, (ulong) slice.Length);
@@ -552,7 +552,7 @@ namespace My.Company
             var slice2_slice = new Sliceu8(slice2_pinned, (ulong) slice2.Length);
             try
             {
-                return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+                return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
             }
             finally
             {
@@ -1201,29 +1201,29 @@ namespace My.Company
             Interop.simple_service_method_mut_self_void(_context, slice);
         }
 
-        public byte MethodMutSelfRef(ref byte x, out byte y)
+        public byte MethodMutSelfRef(ref byte x, ref byte y)
         {
-            return Interop.simple_service_method_mut_self_ref(_context, ref x, out y);
+            return Interop.simple_service_method_mut_self_ref(_context, ref x, ref y);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
         public void MethodMutSelfFfiError(SliceMutu8 slice)

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs
@@ -82,7 +82,7 @@ namespace My.Company
         ///
         /// Parameter x must point to valid data.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
-        public static extern IntPtr ptr_mut(out long x);
+        public static extern IntPtr ptr_mut(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
@@ -91,13 +91,13 @@ namespace My.Company
         public static extern IntPtr ref_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
-        public static extern IntPtr ref_mut_simple(out long x);
+        public static extern IntPtr ref_mut_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
-        public static extern bool ref_mut_option(out long x);
+        public static extern bool ref_mut_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
@@ -624,35 +624,35 @@ namespace My.Company
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
-        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
+        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, ref byte y);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
-        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
+        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, Sliceu8 slice);
 
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, byte[] slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, byte[] slice)
         {
             unsafe
             {
                 fixed (void* ptr_slice = slice)
                 {
                     var slice_slice = new Sliceu8(new IntPtr(ptr_slice), (ulong) slice.Length);
-                    return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+                    return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice)
         {
             var slice_slice = new Sliceu8(slice);
-            return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+            return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
         }
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice_limited")]
-        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
+        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
 
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
             unsafe
             {
@@ -662,18 +662,18 @@ namespace My.Company
                     fixed (void* ptr_slice2 = slice2)
                     {
                         var slice2_slice = new Sliceu8(new IntPtr(ptr_slice2), (ulong) slice2.Length);
-                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
                     }
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
             var slice_slice = new Sliceu8(slice);
             var slice2_slice = new Sliceu8(slice2);
-            return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+            return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
         }
         #endif
 
@@ -1449,42 +1449,42 @@ namespace My.Company
         }
         #endif
 
-        public byte MethodMutSelfRef(ref byte x, out byte y)
+        public byte MethodMutSelfRef(ref byte x, ref byte y)
         {
-            return Interop.simple_service_method_mut_self_ref(_context, ref x, out y);
+            return Interop.simple_service_method_mut_self_ref(_context, ref x, ref y);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, NativeArray<byte> slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, NativeArray<byte> slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
         #endif
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
         #endif
 

--- a/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
+++ b/backends/csharp/tests/output_unity/Assets/Interop.cs.expected
@@ -82,7 +82,7 @@ namespace My.Company
         ///
         /// Parameter x must point to valid data.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
-        public static extern IntPtr ptr_mut(out long x);
+        public static extern IntPtr ptr_mut(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
@@ -91,13 +91,13 @@ namespace My.Company
         public static extern IntPtr ref_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
-        public static extern IntPtr ref_mut_simple(out long x);
+        public static extern IntPtr ref_mut_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
-        public static extern bool ref_mut_option(out long x);
+        public static extern bool ref_mut_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
@@ -624,35 +624,35 @@ namespace My.Company
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
-        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
+        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, ref byte y);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
-        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
+        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, Sliceu8 slice);
 
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, byte[] slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, byte[] slice)
         {
             unsafe
             {
                 fixed (void* ptr_slice = slice)
                 {
                     var slice_slice = new Sliceu8(new IntPtr(ptr_slice), (ulong) slice.Length);
-                    return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+                    return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice)
         {
             var slice_slice = new Sliceu8(slice);
-            return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+            return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
         }
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice_limited")]
-        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
+        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
 
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
             unsafe
             {
@@ -662,18 +662,18 @@ namespace My.Company
                     fixed (void* ptr_slice2 = slice2)
                     {
                         var slice2_slice = new Sliceu8(new IntPtr(ptr_slice2), (ulong) slice2.Length);
-                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
                     }
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
             var slice_slice = new Sliceu8(slice);
             var slice2_slice = new Sliceu8(slice2);
-            return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+            return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
         }
         #endif
 
@@ -1449,42 +1449,42 @@ namespace My.Company
         }
         #endif
 
-        public byte MethodMutSelfRef(ref byte x, out byte y)
+        public byte MethodMutSelfRef(ref byte x, ref byte y)
         {
-            return Interop.simple_service_method_mut_self_ref(_context, ref x, out y);
+            return Interop.simple_service_method_mut_self_ref(_context, ref x, ref y);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, NativeArray<byte> slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, NativeArray<byte> slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
         #endif
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
         #endif
 

--- a/backends/csharp/tests/output_unsafe/Interop.cs
+++ b/backends/csharp/tests/output_unsafe/Interop.cs
@@ -82,7 +82,7 @@ namespace My.Company
         ///
         /// Parameter x must point to valid data.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
-        public static extern IntPtr ptr_mut(out long x);
+        public static extern IntPtr ptr_mut(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
@@ -91,13 +91,13 @@ namespace My.Company
         public static extern IntPtr ref_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
-        public static extern IntPtr ref_mut_simple(out long x);
+        public static extern IntPtr ref_mut_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
-        public static extern bool ref_mut_option(out long x);
+        public static extern bool ref_mut_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
@@ -624,35 +624,35 @@ namespace My.Company
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
-        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
+        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, ref byte y);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
-        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
+        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, Sliceu8 slice);
 
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, byte[] slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, byte[] slice)
         {
             unsafe
             {
                 fixed (void* ptr_slice = slice)
                 {
                     var slice_slice = new Sliceu8(new IntPtr(ptr_slice), (ulong) slice.Length);
-                    return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+                    return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice)
         {
             var slice_slice = new Sliceu8(slice);
-            return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+            return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
         }
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice_limited")]
-        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
+        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
 
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
             unsafe
             {
@@ -662,18 +662,18 @@ namespace My.Company
                     fixed (void* ptr_slice2 = slice2)
                     {
                         var slice2_slice = new Sliceu8(new IntPtr(ptr_slice2), (ulong) slice2.Length);
-                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
                     }
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
             var slice_slice = new Sliceu8(slice);
             var slice2_slice = new Sliceu8(slice2);
-            return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+            return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
         }
         #endif
 
@@ -1449,42 +1449,42 @@ namespace My.Company
         }
         #endif
 
-        public byte MethodMutSelfRef(ref byte x, out byte y)
+        public byte MethodMutSelfRef(ref byte x, ref byte y)
         {
-            return Interop.simple_service_method_mut_self_ref(_context, ref x, out y);
+            return Interop.simple_service_method_mut_self_ref(_context, ref x, ref y);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, NativeArray<byte> slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, NativeArray<byte> slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
         #endif
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
         #endif
 

--- a/backends/csharp/tests/output_unsafe/Interop.cs.expected
+++ b/backends/csharp/tests/output_unsafe/Interop.cs.expected
@@ -82,7 +82,7 @@ namespace My.Company
         ///
         /// Parameter x must point to valid data.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_mut")]
-        public static extern IntPtr ptr_mut(out long x);
+        public static extern IntPtr ptr_mut(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ptr_ptr")]
         public static extern IntPtr ptr_ptr(ref IntPtr x);
@@ -91,13 +91,13 @@ namespace My.Company
         public static extern IntPtr ref_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_simple")]
-        public static extern IntPtr ref_mut_simple(out long x);
+        public static extern IntPtr ref_mut_simple(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_option")]
         public static extern bool ref_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ref_mut_option")]
-        public static extern bool ref_mut_option(out long x);
+        public static extern bool ref_mut_option(ref long x);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "tupled")]
         public static extern Tupled tupled(Tupled x);
@@ -624,35 +624,35 @@ namespace My.Company
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref")]
-        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, out byte y);
+        public static extern byte simple_service_method_mut_self_ref(IntPtr context, ref byte x, ref byte y);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice")]
-        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, Sliceu8 slice);
+        public static extern byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, Sliceu8 slice);
 
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, byte[] slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, byte[] slice)
         {
             unsafe
             {
                 fixed (void* ptr_slice = slice)
                 {
                     var slice_slice = new Sliceu8(new IntPtr(ptr_slice), (ulong) slice.Length);
-                    return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+                    return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice)
+        public static byte simple_service_method_mut_self_ref_slice(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice)
         {
             var slice_slice = new Sliceu8(slice);
-            return simple_service_method_mut_self_ref_slice(context, ref x, out y, slice_slice);;
+            return simple_service_method_mut_self_ref_slice(context, ref x, ref y, slice_slice);;
         }
         #endif
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "simple_service_method_mut_self_ref_slice_limited")]
-        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2);
+        public static extern byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2);
 
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
             unsafe
             {
@@ -662,18 +662,18 @@ namespace My.Company
                     fixed (void* ptr_slice2 = slice2)
                     {
                         var slice2_slice = new Sliceu8(new IntPtr(ptr_slice2), (ulong) slice2.Length);
-                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+                        return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
                     }
                 }
             }
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public static byte simple_service_method_mut_self_ref_slice_limited(IntPtr context, ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
             var slice_slice = new Sliceu8(slice);
             var slice2_slice = new Sliceu8(slice2);
-            return simple_service_method_mut_self_ref_slice_limited(context, ref x, out y, slice_slice, slice2_slice);;
+            return simple_service_method_mut_self_ref_slice_limited(context, ref x, ref y, slice_slice, slice2_slice);;
         }
         #endif
 
@@ -1449,42 +1449,42 @@ namespace My.Company
         }
         #endif
 
-        public byte MethodMutSelfRef(ref byte x, out byte y)
+        public byte MethodMutSelfRef(ref byte x, ref byte y)
         {
-            return Interop.simple_service_method_mut_self_ref(_context, ref x, out y);
+            return Interop.simple_service_method_mut_self_ref(_context, ref x, ref y);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, Sliceu8 slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, Sliceu8 slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, byte[] slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, byte[] slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSlice(ref byte x, out byte y, NativeArray<byte> slice)
+        public byte MethodMutSelfRefSlice(ref byte x, ref byte y, NativeArray<byte> slice)
         {
-            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, out y, slice);
+            return Interop.simple_service_method_mut_self_ref_slice(_context, ref x, ref y, slice);
         }
         #endif
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, Sliceu8 slice, Sliceu8 slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, Sliceu8 slice, Sliceu8 slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, byte[] slice, byte[] slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, byte[] slice, byte[] slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        public byte MethodMutSelfRefSliceLimited(ref byte x, out byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
+        public byte MethodMutSelfRefSliceLimited(ref byte x, ref byte y, NativeArray<byte> slice, NativeArray<byte> slice2)
         {
-            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, out y, slice, slice2);
+            return Interop.simple_service_method_mut_self_ref_slice_limited(_context, ref x, ref y, slice, slice2);
         }
         #endif
 

--- a/examples/complex/bindings/csharp/Interop.cs
+++ b/examples/complex/bindings/csharp/Interop.cs
@@ -47,7 +47,7 @@ namespace My.Company
 
         /// Updates the score.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "example_return_score")]
-        public static extern FFIError example_return_score(IntPtr context, out uint score);
+        public static extern FFIError example_return_score(IntPtr context, ref uint score);
 
         /// Updates the score.
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "example_update_score_by_callback")]
@@ -58,7 +58,7 @@ namespace My.Company
         public static extern FFIError example_write_foreign_type(IntPtr context, ref ThirdPartyVecF32 foreign);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "example_double_super_complex_entity")]
-        public static extern FFIError example_double_super_complex_entity(IntPtr context, ref SuperComplexEntity incoming, out SuperComplexEntity outgoing);
+        public static extern FFIError example_double_super_complex_entity(IntPtr context, ref SuperComplexEntity incoming, ref SuperComplexEntity outgoing);
 
     }
 

--- a/examples/complex/bindings/csharp/Test.cs
+++ b/examples/complex/bindings/csharp/Test.cs
@@ -47,14 +47,16 @@ namespace interop_test
 
                 ammo = 10,
             };
+            uint score = 0;
+            var super2 = new SuperComplexEntity();
 
             IntPtr context_ptr = IntPtr.Zero;
             InteropClass.example_create_context(ref context_ptr);
             InteropClass.example_update_score_by_callback(context_ptr, x => 100);
             InteropClass.example_update_score_by_callback(context_ptr, x => x * 2);
             InteropClass.example_print_score(context_ptr);
-            InteropClass.example_return_score(context_ptr, out var score);
-            InteropClass.example_double_super_complex_entity(context_ptr, ref super1, out var super2);
+            InteropClass.example_return_score(context_ptr, ref score);
+            InteropClass.example_double_super_complex_entity(context_ptr, ref super1, ref super2);
             InteropClass.example_destroy_context(ref context_ptr);
 
             Assert.Equal(score, (uint) 200);


### PR DESCRIPTION
Currently `*mut` pointers generate `out` parameters on the C# backend.
This works for patterns where the C# side is expected to only write to the pointer but breaks down when you want to read from the pointer first.

This PR changes `*mut` to generate `ref` arguments like `*const`.
This is a breaking change for existing code so perhaps there is a better solution? 