### PR TITLE
Add support for repr(packed) and repr(align(n))

### DIFF
--- a/backends/cpython/src/writer.rs
+++ b/backends/cpython/src/writer.rs
@@ -109,6 +109,11 @@ pub trait PythonWriter {
             indented!(w, [_], r#""""{}""""#, documentation)?;
         }
 
+        let alignment = c.meta().alignment();
+        if let Some(align) = alignment {
+            indented!(w, [_], r#"_pack_ = {}"#, align)?;
+        }
+
         w.newline()?;
         if write_for == WriteFor::Code {
             indented!(w, [_], r#"# These fields represent the underlying C data layout"#)?;

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -365,9 +365,14 @@ pub trait CSharpWriter {
         self.write_type_definition_composite_body(w, the_type, WriteFor::Code)
     }
 
-    fn write_type_definition_composite_annotation(&self, w: &mut IndentWriter, _the_type: &CompositeType) -> Result<(), Error> {
+    fn write_type_definition_composite_annotation(&self, w: &mut IndentWriter, the_type: &CompositeType) -> Result<(), Error> {
         indented!(w, r#"[Serializable]"#)?;
-        indented!(w, r#"[StructLayout(LayoutKind.Sequential)]"#)
+        let alignment = the_type.meta().alignment();
+        if let Some(align) = alignment {
+            indented!(w, r#"[StructLayout(LayoutKind.Sequential, Pack = {})]"#, align)
+        } else {
+            indented!(w, r#"[StructLayout(LayoutKind.Sequential)]"#)
+        }
     }
 
     fn write_type_definition_composite_body(&self, w: &mut IndentWriter, the_type: &CompositeType, write_for: WriteFor) -> Result<(), Error> {

--- a/core/src/lang/c.rs
+++ b/core/src/lang/c.rs
@@ -490,6 +490,7 @@ impl OpaqueType {
 pub struct Meta {
     documentation: Documentation,
     namespace: String,
+    alignment: Option<usize>,
 }
 
 impl Meta {
@@ -497,12 +498,12 @@ impl Meta {
         Self::default()
     }
 
-    pub fn with_namespace_documentation(namespace: String, documentation: Documentation) -> Self {
-        Self { documentation, namespace }
+    pub fn with_namespace_documentation(namespace: String, documentation: Documentation, alignment: Option<usize>) -> Self {
+        Self { documentation, namespace, alignment }
     }
 
-    pub fn with_documentation(documentation: Documentation) -> Self {
-        Self::with_namespace_documentation(String::new(), documentation)
+    pub fn with_documentation(documentation: Documentation, alignment: Option<usize>) -> Self {
+        Self::with_namespace_documentation(String::new(), documentation, alignment)
     }
 
     pub fn documentation(&self) -> &Documentation {
@@ -517,6 +518,11 @@ impl Meta {
     pub fn is_namespace(&self, namespace: &str) -> bool {
         self.namespace == namespace
     }
+
+    pub fn alignment(&self) -> Option<usize> {
+        self.alignment
+    }
+
 }
 
 /// A named, exported `#[no_mangle] extern "C" fn f()` function.

--- a/core/src/patterns/option.rs
+++ b/core/src/patterns/option.rs
@@ -145,7 +145,7 @@ where
         ];
 
         let doc = Documentation::from_line("Option type containing boolean flag and maybe valid data.");
-        let meta = Meta::with_namespace_documentation(T::type_info().namespace().map(|e| e.into()).unwrap_or_else(String::new), doc);
+        let meta = Meta::with_namespace_documentation(T::type_info().namespace().map(|e| e.into()).unwrap_or_else(String::new), doc, None);
         let composite = CompositeType::with_meta(format!("Option{}", T::type_info().name_within_lib()), fields, meta);
         CType::Pattern(TypePattern::Option(composite))
     }

--- a/core/src/patterns/slice.rs
+++ b/core/src/patterns/slice.rs
@@ -128,7 +128,7 @@ where
         ];
 
         let doc = Documentation::from_line("A pointer to an array of data someone else owns which may not be modified.");
-        let meta = Meta::with_namespace_documentation(T::type_info().namespace().map(|e| e.into()).unwrap_or_else(String::new), doc);
+        let meta = Meta::with_namespace_documentation(T::type_info().namespace().map(|e| e.into()).unwrap_or_else(String::new), doc, None);
         let composite = CompositeType::with_meta(format!("Slice{}", T::type_info().name_within_lib()), fields, meta);
         CType::Pattern(TypePattern::Slice(composite))
     }
@@ -236,7 +236,7 @@ where
         ];
 
         let doc = Documentation::from_line("A pointer to an array of data someone else owns which may be modified.");
-        let meta = Meta::with_namespace_documentation(T::type_info().namespace().map(|e| e.into()).unwrap_or_else(String::new), doc);
+        let meta = Meta::with_namespace_documentation(T::type_info().namespace().map(|e| e.into()).unwrap_or_else(String::new), doc, None);
         let composite = CompositeType::with_meta(format!("SliceMut{}", T::type_info().name_within_lib()), fields, meta);
         CType::Pattern(TypePattern::SliceMut(composite))
     }

--- a/proc_macros/Cargo.toml
+++ b/proc_macros/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro2 = "1.0.36"
 syn = { version = "1.0.86", features = ["full"] }
 quote = "1.0.15"
 darling = "0.13.1"
+regex = "1.5"
 
 [dev-dependencies]
 interoptopus = { path = "../core" }

--- a/proc_macros/src/constants.rs
+++ b/proc_macros/src/constants.rs
@@ -27,7 +27,7 @@ pub fn ffi_constant(_attr: AttributeArgs, input: TokenStream) -> TokenStream {
             fn constant_info() -> interoptopus::lang::c::Constant {
 
                 let documentation = ::interoptopus::lang::c::Documentation::from_line(#doc_line);
-                let meta = ::interoptopus::lang::c::Meta::with_documentation(documentation);
+                let meta = ::interoptopus::lang::c::Meta::with_documentation(documentation, None);
                 let value = ::interoptopus::lang::c::ConstantValue::from(#const_ident);
 
                 ::interoptopus::lang::c::Constant::new(#const_name.to_string(), value, meta)

--- a/proc_macros/src/functions/freestanding.rs
+++ b/proc_macros/src/functions/freestanding.rs
@@ -169,7 +169,7 @@ pub fn ffi_function_freestanding(_ffi_attributes: &Attributes, input: TokenStrea
 
                 let mut signature = ::interoptopus::lang::c::FunctionSignature::new(params, #rval);
                 let documentation = ::interoptopus::lang::c::Documentation::from_lines(doc_lines);
-                let meta = ::interoptopus::lang::c::Meta::with_documentation(documentation);
+                let meta = ::interoptopus::lang::c::Meta::with_documentation(documentation, None);
 
                 ::interoptopus::lang::c::Function::new(#function_ident_str.to_string(), signature, meta)
             }

--- a/proc_macros/src/types/enums.rs
+++ b/proc_macros/src/types/enums.rs
@@ -103,7 +103,7 @@ pub fn ffi_type_enum(attributes: &Attributes, input: TokenStream, item: ItemEnum
 
                 let mut variants = ::std::vec::Vec::new();
                 let documentation = ::interoptopus::lang::c::Documentation::from_line(#doc_line);
-                let mut meta = ::interoptopus::lang::c::Meta::with_namespace_documentation(#namespace.to_string(), documentation);
+                let mut meta = ::interoptopus::lang::c::Meta::with_namespace_documentation(#namespace.to_string(), documentation, None);
 
                 #({
                     variants.push(Self::#variant_idents.variant_info());

--- a/reference_project/src/types.rs
+++ b/reference_project/src/types.rs
@@ -213,6 +213,36 @@ pub struct Visibility2 {
     pblc2: u8,
 }
 
+#[ffi_type]
+#[repr(C)]
+#[repr(packed)]
+pub struct Packed1 {
+    pub x: u8,
+    pub y: u16,
+}
+
+#[ffi_type]
+#[repr(C, packed)]
+pub struct Packed2 {
+    pub x: u8,
+    pub y: u16,
+}
+
+#[ffi_type]
+#[repr(C)]
+#[repr(align(2))]
+pub struct Align1 {
+    pub x: u8,
+    pub y: u16,
+}
+
+#[ffi_type]
+#[repr(C, align(64))]
+pub struct Align2 {
+    pub x: u8,
+    pub y: u16,
+}
+
 // Doesn't need annotations.
 pub type Callbacku8u8 = extern "C" fn(u8) -> u8;
 


### PR DESCRIPTION
Add support for repr(packed) and repr(align(n)) rust struct in c, c# and python bindings generators.
This update should not affect existing bindings without the packed or align attribute or alter their behavior.