### PR TITLE
fix: generate documentation of fields and enum variants in the C backend

### DIFF
--- a/backends/c/src/writer.rs
+++ b/backends/c/src/writer.rs
@@ -261,6 +261,10 @@ pub trait CWriter {
         let variant_name = self.converter().enum_variant_to_name(the_enum, variant);
         let variant_value = variant.value();
 
+        if self.config().documentation == CDocumentationStyle::Inline {
+            self.write_documentation(w, variant.documentation())?
+        }
+
         indented!(w, r#"{} = {},"#, variant_name, variant_value)
     }
 
@@ -312,6 +316,10 @@ pub trait CWriter {
     }
 
     fn write_type_definition_composite_body_field(&self, w: &mut IndentWriter, field: &Field, _the_type: &CompositeType) -> Result<(), Error> {
+        if self.config().documentation == CDocumentationStyle::Inline {
+            self.write_documentation(w, field.documentation())?;
+        }
+
         match field.the_type() {
             CType::Array(x) => {
                 let field_name = field.name();

--- a/examples/complex/bindings/c/example_complex.h
+++ b/examples/complex/bindings/c/example_complex.h
@@ -21,7 +21,9 @@ const uint32_t THE_MAGIC_CONSTANT = 666;
 /// Possible errors in our library.
 typedef enum ffierror
     {
+    /// All went fine.
     FFIERROR_OK = 0,
+    /// Naughty API call detected.
     FFIERROR_NULLPOINTERPASSED = 10,
     } ffierror;
 
@@ -51,6 +53,7 @@ typedef struct supercomplexentity
     vec3 player_1;
     vec3 player_2;
     uint64_t ammo;
+    /// Point to an ASCII encoded whatnot.
     const uint8_t* some_str;
     uint32_t str_len;
     } supercomplexentity;

--- a/examples/complex/tests/bindings.rs
+++ b/examples/complex/tests/bindings.rs
@@ -28,7 +28,7 @@ fn bindings_csharp() -> Result<(), Error> {
 #[cfg_attr(miri, ignore)]
 fn bindings_c() -> Result<(), Error> {
     use interoptopus_backend_c::compile_c_app_if_installed;
-    use interoptopus_backend_c::{Config, Generator};
+    use interoptopus_backend_c::{Config, Generator, CDocumentationStyle};
 
     let custom_defines = r"
 // Custom attribute.
@@ -41,6 +41,7 @@ fn bindings_c() -> Result<(), Error> {
             ifndef: "example_complex".to_string(),
             function_attribute: "__FUNCTION_ATTR ".to_string(),
             custom_defines,
+            documentation: CDocumentationStyle::Inline,
             ..Config::default()
         },
         example_complex::ffi_inventory(),


### PR DESCRIPTION
I noticed that the C backend was not writing documentation for struct fields or enum variants. This just adds documentation generation to those as well.

Before, `example_complex.h` generated the following:

```
/// Possible errors in our library.
typedef enum ffierror
    {
    FFIERROR_OK = 0,
    FFIERROR_NULLPOINTERPASSED = 10,
    } ffierror;

/// A vector used in our game engine.
typedef struct supercomplexentity
    {
    vec3 player_1;
    vec3 player_2;
    uint64_t ammo;
    const uint8_t* some_str;
    uint32_t str_len;
    } supercomplexentity;


```

whereas now it generates

```
/// Possible errors in our library.
typedef enum ffierror
    {
    /// All went fine.
    FFIERROR_OK = 0,
    /// Naughty API call detected.
    FFIERROR_NULLPOINTERPASSED = 10,
    } ffierror;

/// A vector used in our game engine.
typedef struct supercomplexentity
    {
    vec3 player_1;
    vec3 player_2;
    uint64_t ammo;
    /// Point to an ASCII encoded whatnot.
    const uint8_t* some_str;
    uint32_t str_len;
    } supercomplexentity;
```

I only ran the complex example and committed the changes to the output header file. I am not sure whether other tests are supposed to be run and their output committed as well.