### PR TITLE
Feature/multiple return values

### DIFF
--- a/backends/c/src/converter.rs
+++ b/backends/c/src/converter.rs
@@ -109,6 +109,7 @@ impl CTypeConverter for Converter {
             CType::Pattern(x) => self.to_type_specifier(&x.fallback_type()),
             // TODO: This should be handled in nicer way so that arrays-of-arrays and other thing work properly
             CType::Array(_) => panic!("Arrays need special handling in the writer."),
+            CType::Function(_) => panic!("functions need special handling in the writer"),
         }
     }
 

--- a/backends/c/src/docs.rs
+++ b/backends/c/src/docs.rs
@@ -44,6 +44,7 @@ impl<W: CWriter> DocGenerator<W> {
             CType::ReadPointer(_) => return Ok(()),
             CType::ReadWritePointer(_) => return Ok(()),
             CType::Pattern(_) => return Ok(()),
+            CType::Function(f) => f.meta(),
         };
 
         w.newline()?;

--- a/backends/c/src/writer.rs
+++ b/backends/c/src/writer.rs
@@ -192,6 +192,9 @@ pub trait CWriter {
                 TypePattern::CChar => {}
                 TypePattern::APIVersion => {}
             },
+            CType::Function(_) =>  {
+                // Currently handled elsewhere
+            }
         }
         Ok(())
     }

--- a/backends/c/src/writer.rs
+++ b/backends/c/src/writer.rs
@@ -191,6 +191,9 @@ pub trait CWriter {
                 TypePattern::Bool => {}
                 TypePattern::CChar => {}
                 TypePattern::APIVersion => {}
+                TypePattern::AugmentedFunction(f) => {
+                    self.write_function(w, &f.fallback_type())?;
+                }
             },
             CType::Function(_) =>  {
                 // Currently handled elsewhere

--- a/backends/cpython/src/converter.rs
+++ b/backends/cpython/src/converter.rs
@@ -110,6 +110,7 @@ impl Converter {
                 TypePattern::Bool => "ctypes.c_uint8".to_string(),
                 TypePattern::CChar => "ctypes.c_char".to_string(),
                 TypePattern::NamedCallback(x) => format!("callbacks.{}", safe_name(&x.fnpointer().internal_name())),
+                TypePattern::AugmentedFunction(_) => todo!(),
             },
         }
     }

--- a/backends/cpython/src/converter.rs
+++ b/backends/cpython/src/converter.rs
@@ -70,6 +70,7 @@ impl Converter {
     #[allow(clippy::only_used_in_recursion)]
     pub fn to_ctypes_name(&self, the_type: &CType, with_type_annotations: bool) -> String {
         match the_type {
+            CType::Function(_) => todo!(),
             CType::Primitive(x) => match x {
                 PrimitiveType::Void => "".to_string(),
                 PrimitiveType::Bool => "ctypes.c_bool".to_string(),

--- a/backends/csharp/src/converter.rs
+++ b/backends/csharp/src/converter.rs
@@ -76,6 +76,7 @@ pub trait CSharpTypeConverter {
                 TypePattern::Bool => true,
                 TypePattern::CChar => true,
                 TypePattern::NamedCallback(_) => false,
+                TypePattern::AugmentedFunction(_) => todo!(),
             },
             CType::Array(_) => false, // TODO: should check inner and maybe return true
             CType::Enum(_) => true,
@@ -109,6 +110,7 @@ pub trait CSharpTypeConverter {
             CType::ReadWritePointer(_) => "IntPtr".to_string(),
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(x) => match x {
+                TypePattern::AugmentedFunction(_) => todo!(),
                 TypePattern::AsciiPointer => "string".to_string(),
                 TypePattern::FFIErrorEnum(e) => self.enum_to_typename(e.the_enum()),
                 TypePattern::Slice(e) => self.composite_to_typename(e),
@@ -153,6 +155,7 @@ pub trait CSharpTypeConverter {
             },
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(x) => match x {
+                TypePattern::AugmentedFunction(_) => todo!(),
                 TypePattern::AsciiPointer => "string".to_string(),
                 TypePattern::FFIErrorEnum(e) => self.enum_to_typename(e.the_enum()),
                 TypePattern::Slice(x) => self.composite_to_typename(x),
@@ -178,6 +181,7 @@ pub trait CSharpTypeConverter {
             CType::ReadWritePointer(_) => "IntPtr".to_string(),
             CType::FnPointer(x) => self.fnpointer_to_typename(x),
             CType::Pattern(x) => match x {
+                TypePattern::AugmentedFunction(_) => todo!(),
                 TypePattern::AsciiPointer => "IntPtr".to_string(),
                 TypePattern::FFIErrorEnum(e) => self.enum_to_typename(e.the_enum()),
                 TypePattern::Slice(x) => self.composite_to_typename(x),

--- a/backends/csharp/src/converter.rs
+++ b/backends/csharp/src/converter.rs
@@ -63,6 +63,7 @@ pub trait CSharpTypeConverter {
     /// Checks if the type is on the C# side blittable, in particular, if it can be accessed via raw pointers and memcopied.
     fn is_blittable(&self, x: &CType) -> bool {
         match x {
+            CType::Function(_) => todo!(),
             CType::Primitive(_) => true,
             CType::Composite(c) => c.fields().iter().all(|x| self.is_blittable(x.the_type())),
             CType::Pattern(x) => match x {
@@ -98,6 +99,7 @@ pub trait CSharpTypeConverter {
     #[allow(clippy::only_used_in_recursion)]
     fn to_typespecifier_in_field(&self, x: &CType, field: &Field, composite: &CompositeType) -> String {
         match &x {
+            CType::Function(_) => todo!(),
             CType::Primitive(x) => self.primitive_to_typename(x),
             CType::Array(_) => panic!("Needs special handling in the writer."),
             CType::Enum(x) => self.enum_to_typename(x),
@@ -123,6 +125,7 @@ pub trait CSharpTypeConverter {
     /// Converts the `u32` part in a Rust paramter `x: u32` to a C# equivalent. Might convert pointers to `out X` or `ref X`.
     fn to_typespecifier_in_param(&self, x: &CType) -> String {
         match &x {
+            CType::Function(_) => todo!(),
             CType::Primitive(x) => self.primitive_to_typename(x),
             CType::Array(_) => todo!(),
             CType::Enum(x) => self.enum_to_typename(x),
@@ -165,6 +168,7 @@ pub trait CSharpTypeConverter {
 
     fn to_typespecifier_in_rval(&self, x: &CType) -> String {
         match &x {
+            CType::Function(_) => todo!(),
             CType::Primitive(x) => self.primitive_to_typename(x),
             CType::Array(_) => todo!(),
             CType::Enum(x) => self.enum_to_typename(x),

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -222,6 +222,7 @@ pub trait CSharpWriter {
             CType::ReadPointer(_) => {}
             CType::ReadWritePointer(_) => {}
             CType::Pattern(x) => match x {
+                TypePattern::AugmentedFunction(_) => todo!(),
                 TypePattern::AsciiPointer => {}
                 TypePattern::FFIErrorEnum(e) => {
                     self.write_type_definition_enum(w, e.the_enum(), WriteFor::Code)?;
@@ -509,6 +510,7 @@ pub trait CSharpWriter {
             CType::ReadPointer(_) => false,
             CType::ReadWritePointer(_) => false,
             CType::Pattern(x) => match x {
+                TypePattern::AugmentedFunction(_) => todo!(),
                 TypePattern::AsciiPointer => true,
                 TypePattern::APIVersion => true,
                 TypePattern::FFIErrorEnum(x) => self.should_emit_by_meta(x.the_enum().meta()),

--- a/backends/csharp/src/writer.rs
+++ b/backends/csharp/src/writer.rs
@@ -203,6 +203,7 @@ pub trait CSharpWriter {
         }
 
         match the_type {
+            CType::Function(_) => todo!(),
             CType::Primitive(_) => {}
             CType::Array(_) => {}
             CType::Enum(e) => {
@@ -498,6 +499,7 @@ pub trait CSharpWriter {
         }
 
         match t {
+            CType::Function(_) => todo!(),
             CType::Primitive(_) => self.config().write_types == WriteTypes::NamespaceAndInteroptopusGlobal,
             CType::Array(_) => false,
             CType::Enum(x) => self.should_emit_by_meta(x.meta()),

--- a/core/src/lang/c.rs
+++ b/core/src/lang/c.rs
@@ -121,6 +121,7 @@ pub enum CType {
     /// Special patterns with primitives existing on C-level but special semantics.
     /// useful to higher level languages.
     Pattern(TypePattern),
+    Function(Box<Function>),
 }
 
 impl Default for CType {
@@ -181,6 +182,7 @@ impl CType {
                 _ => x.fallback_type().name_within_lib(),
             },
             CType::Array(x) => x.rust_name(),
+            CType::Function(f) => f.name().to_owned(),
         }
     }
 
@@ -206,6 +208,7 @@ impl CType {
             CType::ReadWritePointer(x) => Some(x.as_ref()),
             CType::Pattern(_) => None,
             CType::Array(_) => None,
+            CType::Function(_) => None,
         }
     }
 

--- a/core/src/patterns/augmented_function.rs
+++ b/core/src/patterns/augmented_function.rs
@@ -1,0 +1,49 @@
+use crate::lang::c::{Meta, Parameter, Function, CType, FunctionSignature};
+
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct AugmentedFunction {
+    name: String,
+    meta: Meta,
+    signature: AugmentedFunctionSignature,
+}
+
+/// Represents multiple `in` and a single `out` parameters.
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
+pub struct AugmentedFunctionSignature {
+    params: Vec<Parameter>,
+
+    // NOTE: This is of type Vec<Parameter> and not Vec<CType> since in the FFI representation of C
+    // we need to name the output parameters
+    rvals: Vec<Parameter>,
+
+    // TODO: here you can put errors that will be translated into exceptions etc by whatever back
+    // end is being used
+}
+
+impl AugmentedFunctionSignature {
+    fn fallback_type(&self) -> FunctionSignature {
+        if self.rvals.len() == 1 {
+            FunctionSignature::new(self.params.clone(), self.rvals[0].the_type().to_owned())
+        } else {
+            let mut params = self.params.clone();
+            params.extend(
+                self.rvals.iter().map(|rval| Parameter::new(
+                    rval.name().to_owned(),
+                    CType::ReadWritePointer(Box::new(rval.the_type().to_owned()))
+                )
+            ));
+
+            FunctionSignature::new(params, CType::Primitive(crate::lang::c::PrimitiveType::Void))
+        }
+    }
+}
+
+impl AugmentedFunction {
+    pub fn fallback_type(&self) -> CType {
+        let f = Function::new(
+            self.name.clone(), self.signature.fallback_type(), self.meta.clone()
+        );
+
+        CType::Function(Box::new(f))
+    }
+}

--- a/core/src/patterns/augmented_function.rs
+++ b/core/src/patterns/augmented_function.rs
@@ -39,11 +39,11 @@ impl AugmentedFunctionSignature {
 }
 
 impl AugmentedFunction {
-    pub fn fallback_type(&self) -> CType {
+    pub fn fallback_type(&self) -> Function {
         let f = Function::new(
             self.name.clone(), self.signature.fallback_type(), self.meta.clone()
         );
 
-        CType::Function(Box::new(f))
+        f
     }
 }

--- a/core/src/patterns/mod.rs
+++ b/core/src/patterns/mod.rs
@@ -75,6 +75,8 @@ use crate::patterns::callbacks::NamedCallback;
 use crate::patterns::result::FFIErrorEnum;
 use crate::patterns::service::Service;
 
+use augmented_function::AugmentedFunction;
+
 #[doc(hidden)]
 pub mod api_entry;
 pub mod api_guard;
@@ -85,6 +87,7 @@ pub mod result;
 pub mod service;
 pub mod slice;
 pub mod string;
+pub mod augmented_function;
 
 /// A pattern on a library level, usually involving both methods and types.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -116,6 +119,7 @@ pub enum TypePattern {
     Bool,
     CChar,
     NamedCallback(NamedCallback),
+    AugmentedFunction(AugmentedFunction),
 }
 
 impl TypePattern {
@@ -134,6 +138,7 @@ impl TypePattern {
             TypePattern::Bool => CType::Primitive(PrimitiveType::U8),
             TypePattern::CChar => CType::Primitive(PrimitiveType::I8),
             TypePattern::APIVersion => CType::Primitive(PrimitiveType::U64),
+            TypePattern::AugmentedFunction(f) => f.fallback_type(),
         }
     }
 }

--- a/core/src/patterns/mod.rs
+++ b/core/src/patterns/mod.rs
@@ -138,7 +138,7 @@ impl TypePattern {
             TypePattern::Bool => CType::Primitive(PrimitiveType::U8),
             TypePattern::CChar => CType::Primitive(PrimitiveType::I8),
             TypePattern::APIVersion => CType::Primitive(PrimitiveType::U64),
-            TypePattern::AugmentedFunction(f) => f.fallback_type(),
+            TypePattern::AugmentedFunction(f) => CType::Function(Box::new(f.fallback_type())),
         }
     }
 }

--- a/core/src/patterns/service.rs
+++ b/core/src/patterns/service.rs
@@ -246,5 +246,6 @@ fn extract_obvious_opaque_from_parameter(param: &CType) -> Option<OpaqueType> {
         CType::ReadWritePointer(x) => extract_obvious_opaque_from_parameter(x),
         CType::Pattern(_) => None,
         CType::Array(_) => None,
+        CType::Function(_) => None,
     }
 }

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -182,6 +182,13 @@ pub(crate) fn ctypes_from_type_recursive(start: &CType, types: &mut HashSet<CTyp
             TypePattern::Bool => {}
             TypePattern::CChar => {}
             TypePattern::APIVersion => {}
+            TypePattern::AugmentedFunction(f) => {
+                let f = f.fallback_type();
+                ctypes_from_type_recursive(f.signature().rval(), types);
+                for param in f.signature().params() {
+                    ctypes_from_type_recursive(param.the_type(), types);
+                }
+            }
         },
         CType::Function(f) => {
             ctypes_from_type_recursive(f.signature().rval(), types);
@@ -229,6 +236,7 @@ pub(crate) fn extract_namespaces_from_types(types: &[CType], into: &mut HashSet<
                 TypePattern::Bool => {}
                 TypePattern::CChar => {}
                 TypePattern::NamedCallback(_) => {}
+                TypePattern::AugmentedFunction(_) => {}
             },
             CType::Function(_) => {}
         }
@@ -325,6 +333,7 @@ pub fn is_global_type(t: &CType) -> bool {
             TypePattern::Bool => true,
             TypePattern::CChar => true,
             TypePattern::NamedCallback(_) => false,
+            TypePattern::AugmentedFunction(_) => false,
         },
         CType::Function(_) => false,
     }

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -183,6 +183,12 @@ pub(crate) fn ctypes_from_type_recursive(start: &CType, types: &mut HashSet<CTyp
             TypePattern::CChar => {}
             TypePattern::APIVersion => {}
         },
+        CType::Function(f) => {
+            ctypes_from_type_recursive(f.signature().rval(), types);
+            for param in f.signature().params() {
+                ctypes_from_type_recursive(param.the_type(), types);
+            }
+        }
     }
 }
 
@@ -224,6 +230,7 @@ pub(crate) fn extract_namespaces_from_types(types: &[CType], into: &mut HashSet<
                 TypePattern::CChar => {}
                 TypePattern::NamedCallback(_) => {}
             },
+            CType::Function(_) => {}
         }
     }
 }
@@ -319,6 +326,7 @@ pub fn is_global_type(t: &CType) -> bool {
             TypePattern::CChar => true,
             TypePattern::NamedCallback(_) => false,
         },
+        CType::Function(_) => false,
     }
 }
 

--- a/examples/hello_world/bindings/c/example_complex.h
+++ b/examples/hello_world/bindings/c/example_complex.h
@@ -24,6 +24,11 @@ typedef struct vec2
 /// Function using the type.
 vec2 my_function(vec2 input);
 
+/// Function using the type.
+void my_function2(vec2 input);
+
+void my_function3();
+
 
 #ifdef __cplusplus
 }

--- a/examples/hello_world/bindings/c/example_complex.h
+++ b/examples/hello_world/bindings/c/example_complex.h
@@ -27,7 +27,7 @@ vec2 my_function(vec2 input);
 /// Function using the type.
 void my_function2(vec2 input);
 
-void my_function3();
+void my_function3(vec2 input, int32_t* out_param_0, int32_t* out_param_1);
 
 
 #ifdef __cplusplus

--- a/examples/hello_world/bindings/csharp/Interop.cs
+++ b/examples/hello_world/bindings/csharp/Interop.cs
@@ -28,7 +28,7 @@ namespace My.Company
         public static extern void my_function2(Vec2 input);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "my_function3")]
-        public static extern void my_function3();
+        public static extern void my_function3(Vec2 input, out int out_param_0, out int out_param_1);
 
     }
 

--- a/examples/hello_world/bindings/csharp/Interop.cs
+++ b/examples/hello_world/bindings/csharp/Interop.cs
@@ -23,6 +23,13 @@ namespace My.Company
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "my_function")]
         public static extern Vec2 my_function(Vec2 input);
 
+        /// Function using the type.
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "my_function2")]
+        public static extern void my_function2(Vec2 input);
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "my_function3")]
+        public static extern void my_function3();
+
     }
 
     /// A simple type in our FFI layer.

--- a/examples/hello_world/bindings/python/example_complex.py
+++ b/examples/hello_world/bindings/python/example_complex.py
@@ -11,6 +11,8 @@ def init_lib(path):
     c_lib = ctypes.cdll.LoadLibrary(path)
 
     c_lib.my_function.argtypes = [Vec2]
+    c_lib.my_function2.argtypes = [Vec2]
+    c_lib.my_function3.argtypes = []
 
     c_lib.my_function.restype = Vec2
 
@@ -19,6 +21,13 @@ def init_lib(path):
 def my_function(input: Vec2) -> Vec2:
     """ Function using the type."""
     return c_lib.my_function(input)
+
+def my_function2(input: Vec2):
+    """ Function using the type."""
+    return c_lib.my_function2(input)
+
+def my_function3():
+    return c_lib.my_function3()
 
 
 

--- a/examples/hello_world/bindings/python/example_complex.py
+++ b/examples/hello_world/bindings/python/example_complex.py
@@ -12,7 +12,7 @@ def init_lib(path):
 
     c_lib.my_function.argtypes = [Vec2]
     c_lib.my_function2.argtypes = [Vec2]
-    c_lib.my_function3.argtypes = []
+    c_lib.my_function3.argtypes = [Vec2, ctypes.POINTER(ctypes.c_int32), ctypes.POINTER(ctypes.c_int32)]
 
     c_lib.my_function.restype = Vec2
 
@@ -26,8 +26,8 @@ def my_function2(input: Vec2):
     """ Function using the type."""
     return c_lib.my_function2(input)
 
-def my_function3():
-    return c_lib.my_function3()
+def my_function3(input: Vec2, out_param_0: ctypes.POINTER(ctypes.c_int32), out_param_1: ctypes.POINTER(ctypes.c_int32)):
+    return c_lib.my_function3(input, out_param_0, out_param_1)
 
 
 

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -3,6 +3,7 @@ use interoptopus::{ffi_function, ffi_type, function, Inventory, InventoryBuilder
 /// A simple type in our FFI layer.
 #[ffi_type]
 #[repr(C)]
+#[derive(Clone)]
 pub struct Vec2 {
     pub x: f32,
     pub y: f32,
@@ -15,10 +16,28 @@ pub extern "C" fn my_function(input: Vec2) -> Vec2 {
     input
 }
 
+/// Function using the type.
+#[ffi_function]
+#[no_mangle]
+pub extern "C" fn my_function2(input: Vec2) -> () {
+
+}
+
+/// Function using the type.
+#[ffi_function]
+#[no_mangle]
+pub extern "C" fn my_function3(input: Vec2) -> (i32, i32) {
+    (1, 2)
+}
+
 // This will create a function `my_inventory` which can produce
 // an abstract FFI representation (called `Library`) for this crate.
 pub fn my_inventory() -> Inventory {
     {
-        InventoryBuilder::new().register(function!(my_function)).inventory()
+        InventoryBuilder::new()
+            .register(function!(my_function))
+            .register(function!(my_function2))
+            .register(function!(my_function3))
+            .inventory()
     }
 }


### PR DESCRIPTION
**DO NOT MERGE THIS**

This is a first exploration on the discussion [here](https://github.com/ralfbiedert/interoptopus/issues/28). I have not made much attempt at making the code elegant at this point.

I have added a new pattern, the `AugmentedFunction`. Currently, this pattern can be used to return multiple return values, but theoretically it could be updated to also handle fallible functions. The goal would be to eventually add something similar for the service pattern, but I have left this as out of scope for the current exploration.

I have not attempted to write the back-end writers for cpython and C# yet, as I'm not experienced with creating bindings there. I have for now only shown how the C back-end would be modified.

I am having some difficulty understanding how to run all the tests. For now, I have done some basic testing inside of the `hello_world` example by calling `cargo test` there, and inspecting the generated C header file that gets generated.

I've been using `cargo expand` inside of the `hello_world` example to inspect what the proc macros are generating. In a nutshell, the idea is that clients write:

```Rust
/// Function using the type.
#[ffi_function]
#[no_mangle]
pub extern "C" fn my_function3(input: Vec2) -> (i32, i32) {
    (1, 2)
}
```

This function will then get renamed by the macro to `my_function3_interoptopus_internal`. The macro will also generate another new function with the original name `my_function3` that contains OUT parameters. The output of of this macro, obtained by `cargo expand`, for this example is currently:

```rust
/// Function using the type.
#[no_mangle]
pub extern "C" fn my_function3_interoptopus_internal(input: Vec2) -> (i32, i32) {
    (1, 2)
}

/// TODO put the documentation strings here
#[no_mangle]
pub extern "C" fn my_function3(
    input: Vec2,
    out_param_0: *mut i32,
    out_param_1: *mut i32,
) {
    let (return_value_0, return_value_1) = my_function3_interoptopus_internal(input);
    unsafe {
        *out_param_0 = return_value_0;
        *out_param_1 = return_value_1;
    }
}
```

For now I have not attempted to add user-defined names for the OUT parameters. This could be done by adding arguments to the `ffi_function` attribute macro, but has been left as an open point for now.

The header file that is generated contains the following:

```c
void my_function3(vec2 input, int32_t* out_param_0, int32_t* out_param_1);
```

The function `my_function3_interoptopus_internal` is not exposed in the header function.

The idea is that the backend writers realise that they are dealing with an `AugmentedFunction` and translate the OUT parameters into something that is idiomatic for them. For instance, Python could return a tuple directly.

Note that, since the macro works with tokens and not type information, the user cannot write something like

```Rust
type MultipleOutput = (f32, i32);
#[no_mangle]
pub extern "C" fn foo() -> MultipleOutput {
    todo!()
}
```

The macro needs to see the tuple in the token stream in order to realise that this is an augmented function with multiple return values.

At this stage I am not 100% sure whether the `AugmentedFunction` pattern has been hooked up properly to the writers. The function is still exposed via the `function!` macro. I'm not sure if this function will have to be edited, or whether the definition of `FunctionInfo` should be changed such that `AugmentedFunction` will be received by the backend writers.

Finally, fallible functions could be added to this `AugmentedFunction` by adding another OUT parameter representing the error type. The function would then return an enum for the success status of the function call.