### PR TITLE
Explicit drop of Boxed context pointers in ffi_service and complex example context destruction

### DIFF
--- a/examples/complex/src/ffi.rs
+++ b/examples/complex/src/ffi.rs
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn example_destroy_context(context_ptr: Option<&mut *mut C
     let ctx = context_ptr.unwrap();
 
     {
-        unsafe { Box::from_raw(*ctx) };
+        unsafe { drop(Box::from_raw(*ctx)) };
     }
 
     *ctx = null_mut();

--- a/proc_macros/src/service/function_impl.rs
+++ b/proc_macros/src/service/function_impl.rs
@@ -270,7 +270,7 @@ pub fn generate_service_dtor(attributes: &Attributes, impl_block: &ItemImpl) -> 
             }
 
             let result_result = ::std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                unsafe { ::std::boxed::Box::from_raw(*context) };
+                unsafe { drop(::std::boxed::Box::from_raw(*context)) };
             }));
 
             *context = ::std::ptr::null_mut();


### PR DESCRIPTION
The `ffi_service` macro generates code that raises `unused_must_use` warnings on build. That same pattern is used in the FFI function `example_destroy_context`.

```
   Compiling example_complex v0.1.1 (C:\Users\kin_s\prog\rust\interoptopus\examples\complex)
warning: unused return value of `Box::<T>::from_raw` that must be used
  --> examples\complex\src\ffi.rs:89:18
   |
89 |         unsafe { Box::from_raw(*ctx) };
   |                  ^^^^^^^^^^^^^^^^^^^
   |
   = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
89 |         unsafe { let _ = Box::from_raw(*ctx); };
   |                  +++++++                    +

warning: unused return value of `Box::<T>::from_raw` that must be used
  --> reference_project\src\patterns\service.rs:20:6
   |
20 | impl SimpleService {
   |      ^^^^^^^^^^^^^
   |
   = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
   = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
   |
20 | impl let _ = SimpleService; {
   |      +++++++              +

warning: unused return value of `Box::<T>::from_raw` that must be used
   --> reference_project\src\patterns\service.rs:155:10
    |
155 | impl<'a> SimpleServiceLifetime<'a> {
    |          ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
help: use `let _ = ...` to ignore the resulting value
    |
155 | impl<'a> let _ = SimpleServiceLifetime;<'a> {
    |          +++++++                      +

warning: `example_complex` (lib) generated 1 warning
```

To the best of my ability, the intent here was to drop the context object. The drop _is_ happening with current code, so there's no memory leak. This is really about satisfying the compiler.

Because the warning occurs in generated code, I did not find a good way to use a targeted `#[allow(unused_must_use)]` for this issue. `#![allow(unused_must_use)]` worked, but applies to a very broad scope and could mask legit issues.

I recommend making the `drop()` explicit to remove the warning. This should not change the runtime behavior of the generated code otherwise.