### PR TITLE
Added support for extracting the fn from a macro callback

### DIFF
--- a/core/src/patterns/callbacks.rs
+++ b/core/src/patterns/callbacks.rs
@@ -160,6 +160,12 @@ macro_rules! callback {
             }
         }
 
+        impl From<$name> for Option<extern "C" fn($($ty),*) -> $rval> {
+            fn from(x: $name) -> Self {
+                x.0
+            }
+        }
+
         unsafe impl interoptopus::lang::rust::CTypeInfo for $name {
             fn type_info() -> interoptopus::lang::c::CType {
                 use interoptopus::lang::rust::CTypeInfo;


### PR DESCRIPTION
This allows wrappers to be easily (and generically) be implemented for callbacks.
```rust
callback!(MyCallback(value: u32) -> u32);

fn wrap_callback<Arg, Ret, Callback>(wrapper: Callback, arg: Arg) -> Ret
where
    Callback: Into<Option<extern "C" fn(Arg) -> Ret>>,
    Ret: Default,
{
    // log that it was called or something.
    if let Some(callback) = wrapper.into() {
        callback(arg)
    } else {
        Default::default()
    }
}

#[ffi_function]
#[no_mangle]
pub extern "C" fn pattern_callback_1(callback: MyCallback, x: u32) -> u32 {
    wrap_callback(callback, x)
}
```