### PR TITLE
Added panic message extraction.

### DIFF
--- a/core/src/patterns/result.rs
+++ b/core/src/patterns/result.rs
@@ -221,7 +221,7 @@ pub fn get_panic_message(pan: &(dyn Any + Send)) -> &str {
     match pan.downcast_ref::<&'static str>() {
         Some(s) => *s,
         None => match pan.downcast_ref::<String>() {
-            Some(s) => &s,
+            Some(s) => s,
             None => "Any { .. }",
         },
     }

--- a/core/src/patterns/result.rs
+++ b/core/src/patterns/result.rs
@@ -201,7 +201,7 @@ where
     let result: Result<(), E> = match std::panic::catch_unwind(AssertUnwindSafe(f)) {
         Ok(x) => x,
         Err(e) => {
-            log_error(|| format!("Panic in ({}): {:#?}", error_context, get_panic_message(e.as_ref())));
+            log_error(|| format!("Panic in ({}): {}", error_context, get_panic_message(e.as_ref())));
             return FE::PANIC;
         }
     };

--- a/proc_macros/src/service/function_impl.rs
+++ b/proc_macros/src/service/function_impl.rs
@@ -164,7 +164,7 @@ pub fn generate_service_method(attributes: &Attributes, impl_block: &ItemImpl, f
                         }
 
                         Err(e) => {
-                            ::interoptopus::util::log_error(|| format!("Panic in ({}): {:?}", stringify!(#ffi_fn_ident), e));
+                            ::interoptopus::util::log_error(|| format!("Panic in ({}): {}", stringify!(#ffi_fn_ident), ::interoptopus::patterns::result::get_panic_message(e.as_ref())));
                             <#error_ident as ::interoptopus::patterns::result::FFIError>::PANIC
                         }
                     }
@@ -193,7 +193,7 @@ pub fn generate_service_method(attributes: &Attributes, impl_block: &ItemImpl, f
                         match result_result {
                             Ok(x) => x,
                             Err(e) => {
-                                ::interoptopus::util::log_error(|| format!("Panic in ({}): {:?}", stringify!(#ffi_fn_ident), e));
+                                ::interoptopus::util::log_error(|| format!("Panic in ({}): {}", stringify!(#ffi_fn_ident), ::interoptopus::patterns::result::get_panic_message(e.as_ref())));
                                 <#rval>::default()
                             }
                         }
@@ -278,7 +278,7 @@ pub fn generate_service_dtor(attributes: &Attributes, impl_block: &ItemImpl) -> 
             match result_result {
                 Ok(_) => <#error_ident as ::interoptopus::patterns::result::FFIError>::SUCCESS,
                 Err(e) => {
-                    ::interoptopus::util::log_error(|| format!("Panic in ({}): {:?}", stringify!(#ffi_fn_ident), e));
+                    ::interoptopus::util::log_error(|| format!("Panic in ({}): {}", stringify!(#ffi_fn_ident), ::interoptopus::patterns::result::get_panic_message(e.as_ref())));
                     <#error_ident as ::interoptopus::patterns::result::FFIError>::PANIC
                 }
             }


### PR DESCRIPTION
This fixed panic messages being logged as:
`Panic in (...): Any { .. }` (the Any { .. } is literal, it's not a formatted string)
Now they're logged as:
`Panic in (...): <the text of the panic if it's a string>`

This code is based on https://github.com/guswynn/panic-message , which is based on https://github.com/rust-lang/rust/blob/4b9f4b221b92193c7e95b1beb502c6eb32c3b613/library/std/src/panicking.rs#L194-L200

It was verified to work locally with string based panics, custom formats won't work as well, but... dunno what to do about that.