### PR TITLE
docs: AsciiPointer - explain the antipattern with FFIOption

### DIFF
--- a/core/src/patterns/string.rs
+++ b/core/src/patterns/string.rs
@@ -40,6 +40,15 @@ use std::ptr::null;
 static EMPTY: &[u8] = b"\0";
 
 /// Represents a `*const char` on FFI level pointing to an `0x0` terminated ASCII string.
+///
+/// # Antipattern
+///
+/// It's discouraged to use [`FFIOption`](crate::patterns::option::FFIOption) with [`AsciiPointer`]
+/// and some backend might not generate proper bindings (like the C# backend).
+///
+/// Instead use [`AsciiPointer`] alone since it already has a pointer that's `null`able.
+/// In this case, [`AsciiPointer::as_c_str()`] will return [`None`] and [`AsciiPointer::as_str`]
+/// will return an [`Error::Null`].
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct AsciiPointer<'a> {


### PR DESCRIPTION
Closes #114 

Honestly, I think that C# backend should automatically strip the FFIOption or the macros should not allow FFIOption  to work with AsciiPointer.
For now I've only added documentation to AsciiPointer and this anitpattern.