### PR TITLE
Added 'new' Function to C Backend Converter

### DIFF
--- a/crates/backend_c/src/converter.rs
+++ b/crates/backend_c/src/converter.rs
@@ -11,6 +11,14 @@ pub struct Converter {
     pub(crate) config: Config,
 }
 
+impl Converter {
+	pub fn new(config: Config) -> Self {
+		Self {
+			config
+		}
+	}
+}
+
 /// Converts Interoptopus types to C types.
 pub trait CTypeConverter {
     fn config(&self) -> &Config;

--- a/crates/backend_c/src/lib.rs
+++ b/crates/backend_c/src/lib.rs
@@ -136,7 +136,7 @@ impl Generator {
         Self {
             config: config.clone(),
             inventory,
-            converter: Converter { config },
+            converter: Converter::new(config),
         }
     }
 }


### PR DESCRIPTION
Without any public API to construct a new Converter, the 'CWriter' trait cannot be effectively implemented to customize output. This would require *also* implementing the Converter's logic, something which is far more work to do.

If there's some reason this was excluded, please do let me know.