### PR TITLE
Dont allow service fns without self

### DIFF
--- a/examples/real_project_layout/core_library_ffi/src/engine.rs
+++ b/examples/real_project_layout/core_library_ffi/src/engine.rs
@@ -34,6 +34,11 @@ impl GameEngine {
     pub fn num_objects(&self) -> u32 {
         self.engine.num_objects()
     }
+
+    #[ffi_service_method(ignore)]
+    pub fn test(_test: u32) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 // Our FFI `Vec2` type.


### PR DESCRIPTION
This PR is based on #130, so I could check the tests locally as well. Feel free to not pull those in, or tell me and I'll remove them.

----

This PR fixes #129, as it simply compile-errors when trying to use a first argument that is not either a:

- An actual receiver `(&self, &mut self, self: Box<val>, etc...)`
- A reference to itself `impl Service { fn foo(instance: &Service) { ..} }`

Anything else will fail the equality check and stop compilation.

The error message is not the best, but should give some indication on what went wrong.

Sadly at macro-level there is no way to verify type equality.

There's also IMO quite some unsoundness around lifetimes, but this PR should preserve any previous behaviour (as it only emits a check).