### PR TITLE
Change CWriter's Converter to an Assoc Type

### DIFF
--- a/crates/backend_c/src/converter.rs
+++ b/crates/backend_c/src/converter.rs
@@ -21,42 +21,6 @@ impl Converter {
 pub trait CTypeConverter {
     fn config(&self) -> &Config;
 
-    /// Converts a primitive (Rust) type to a native C# type name, e.g., `f32` to `float`.
-    fn primitive_to_typename(&self, x: &PrimitiveType) -> String;
-
-    /// Converts a Rust enum name such as `Error` to a C# enum name `Error`.
-    fn enum_to_typename(&self, x: &EnumType) -> String;
-
-    fn enum_variant_to_name(&self, the_enum: &EnumType, x: &Variant) -> String;
-
-    /// TODO Converts an opaque Rust struct `Context` to a C# struct ``.
-    fn opaque_to_typename(&self, opaque: &OpaqueType) -> String;
-
-    /// Converts an Rust struct name `Vec2` to a C# struct name `Vec2`.
-    fn composite_to_typename(&self, x: &CompositeType) -> String;
-
-    /// Converts an Rust `fn()` to a C# delegate name such as `InteropDelegate`.
-    fn fnpointer_to_typename(&self, x: &FnPointerType) -> String;
-
-    fn named_callback_to_typename(&self, x: &NamedCallback) -> String {
-        format!("{}{}", self.config().prefix, x.name().to_naming_style(&self.config().type_naming))
-    }
-
-    /// Converts the `u32` part in a Rust paramter `x: u32` to a C# equivalent. Might convert pointers to `out X` or `ref X`.
-    fn to_type_specifier(&self, x: &CType) -> String;
-
-    fn const_name_to_name(&self, x: &Constant) -> String;
-
-    fn constant_value_to_value(&self, value: &ConstantValue) -> String;
-
-    fn function_name_to_c_name(&self, function: &Function) -> String;
-}
-
-impl CTypeConverter for Converter {
-    fn config(&self) -> &Config {
-        &self.config
-    }
-
     fn primitive_to_typename(&self, x: &PrimitiveType) -> String {
         match x {
             PrimitiveType::Void => "void".to_string(),
@@ -75,30 +39,34 @@ impl CTypeConverter for Converter {
     }
 
     fn enum_to_typename(&self, x: &EnumType) -> String {
-        format!("{}{}", self.config().prefix, x.rust_name()).to_naming_style(&self.config.type_naming)
+        format!("{}{}", self.config().prefix, x.rust_name()).to_naming_style(&self.config().type_naming)
     }
 
     fn enum_variant_to_name(&self, the_enum: &EnumType, x: &Variant) -> String {
         format!(
             "{}{}_{}",
             self.config().prefix,
-            the_enum.rust_name().to_naming_style(&self.config.type_naming),
+            the_enum.rust_name().to_naming_style(&self.config().type_naming),
             x.name()
         )
-        .to_naming_style(&self.config.enum_variant_naming)
+        .to_naming_style(&self.config().enum_variant_naming)
     }
 
     fn opaque_to_typename(&self, x: &OpaqueType) -> String {
-        format!("{}{}", self.config().prefix, x.rust_name()).to_naming_style(&self.config.type_naming)
+        format!("{}{}", self.config().prefix, x.rust_name()).to_naming_style(&self.config().type_naming)
     }
 
     fn composite_to_typename(&self, x: &CompositeType) -> String {
-        format!("{}{}", self.config().prefix, x.rust_name()).to_naming_style(&self.config.type_naming)
+        format!("{}{}", self.config().prefix, x.rust_name()).to_naming_style(&self.config().type_naming)
     }
 
     fn fnpointer_to_typename(&self, x: &FnPointerType) -> String {
         let prefixed = format!("{}fptr", self.config().prefix);
         [prefixed, safe_name(&x.internal_name())].join("_")
+    }
+
+    fn named_callback_to_typename(&self, x: &NamedCallback) -> String {
+        format!("{}{}", self.config().prefix, x.name().to_naming_style(&self.config().type_naming))
     }
 
     fn to_type_specifier(&self, x: &CType) -> String {
@@ -119,7 +87,7 @@ impl CTypeConverter for Converter {
     }
 
     fn const_name_to_name(&self, x: &Constant) -> String {
-        format!("{}{}", self.config().prefix, x.name()).to_naming_style(&self.config.const_naming)
+        format!("{}{}", self.config().prefix, x.name()).to_naming_style(&self.config().const_naming)
     }
 
     fn constant_value_to_value(&self, value: &ConstantValue) -> String {
@@ -142,5 +110,11 @@ impl CTypeConverter for Converter {
 
     fn function_name_to_c_name(&self, function: &Function) -> String {
         function.name().to_string()
+    }
+}
+
+impl CTypeConverter for Converter {
+    fn config(&self) -> &Config {
+        &self.config
     }
 }

--- a/crates/backend_c/src/lib.rs
+++ b/crates/backend_c/src/lib.rs
@@ -149,6 +149,8 @@ impl Interop for Generator {
 }
 
 impl CWriter for Generator {
+    type Converter = Converter;
+
     fn config(&self) -> &Config {
         &self.config
     }

--- a/crates/backend_c/src/writer.rs
+++ b/crates/backend_c/src/writer.rs
@@ -8,11 +8,12 @@ use interoptopus::{Error, Inventory};
 
 use crate::config::{CDocumentationStyle, CFunctionStyle, CIndentationStyle, ToNamingStyle};
 use crate::converter::CTypeConverter;
-use crate::converter::Converter;
 use crate::Config;
 
 /// Writes the C file format, `impl` this trait to customize output.
 pub trait CWriter {
+    type Converter: CTypeConverter;
+
     /// Returns the user config.
     fn config(&self) -> &Config;
 
@@ -20,7 +21,7 @@ pub trait CWriter {
     fn inventory(&self) -> &Inventory;
 
     /// Returns the library to produce bindings for.
-    fn converter(&self) -> &Converter;
+    fn converter(&self) -> &Self::Converter;
 
     fn write_custom_defines(&self, w: &mut IndentWriter) -> Result<(), Error> {
         indented!(w, "{}", &self.config().custom_defines)


### PR DESCRIPTION
The CTypeConverter doesn't follow the same pattern as the CWriter (implementing a trait of mostly default fns) making it very difficult to alter the functionality of. In addition, CWriter itself uses a static Converter type, disallowing altering it at all.
This pr changes the Converter CWriter uses to an associated type, allowing any type to be used in implementations of CWriter, whether or not they change any other logic.

I was going to do the same for the Python and C# backends, but I noticed their converters didn't implement Traits at all, so I left them alone. I'm happy to do the same for them if this change is favourable.

This is a breaking change of course since implementations of CWriter will need to add the new associated type (something default assoc types would fix :pensive:).