### PR TITLE
C# Backend: Generate a ToString override for enums

### DIFF
--- a/crates/backend_csharp/src/interop/types/enums.rs
+++ b/crates/backend_csharp/src/interop/types/enums.rs
@@ -230,6 +230,26 @@ pub fn write_type_definition_enum_variant_utils(i: &Interop, w: &mut IndentWrite
     }
     w.newline()?;
 
+    // Somewhat of a ToString implementation.
+    indented!(w, [()], r"public override readonly string ToString() {{")?;
+    indented!(w, [()()], r"return _variant switch {{")?;
+    for variant in the_type.variants() {
+        let vname = format!(r#""{}""#, variant.name());
+        match variant.kind() {
+            VariantKind::Unit(x) => {
+                indented!(w, [()()], r"{x} => {vname},")?;
+            }
+            VariantKind::Typed(x, _) => {
+                indented!(w, [()()], r"{x} => {vname},")?;
+            }
+        }
+    }
+    let throw = "throw new InteropException()";
+    indented!(w, [()()], r"_ => {throw}")?;
+    indented!(w, [()()], r"}};")?;
+    indented!(w, [()], r"}}")?;
+    w.newline()?;
+
     Ok(())
 }
 

--- a/examples/real_project_layout/core_library_ffi_build/bindings/Interop.cs
+++ b/examples/real_project_layout/core_library_ffi_build/bindings/Interop.cs
@@ -98,6 +98,13 @@ namespace My.Company
 
         public void AsFail() { if (_variant != 0) throw new InteropException(); }
 
+        public override readonly string ToString() {
+            return _variant switch {
+            0 => "Fail",
+            _ => throw new InteropException()
+            };
+        }
+
         public ref struct Marshaller
         {
             private Error _managed; // Used when converting managed -> unmanaged
@@ -280,6 +287,16 @@ namespace My.Company
         public void AsPanic() { if (_variant != 2) throw new InteropException(); }
         public void AsNull() { if (_variant != 3) throw new InteropException(); }
 
+        public override readonly string ToString() {
+            return _variant switch {
+            0 => "Ok",
+            1 => "Err",
+            2 => "Panic",
+            3 => "Null",
+            _ => throw new InteropException()
+            };
+        }
+
         public ref struct Marshaller
         {
             private ResultConstPtrGameEngineError _managed; // Used when converting managed -> unmanaged
@@ -381,6 +398,16 @@ namespace My.Company
         public Error AsErr() { if (_variant != 1) { throw new InteropException(); } else { return _Err; } }
         public void AsPanic() { if (_variant != 2) throw new InteropException(); }
         public void AsNull() { if (_variant != 3) throw new InteropException(); }
+
+        public override readonly string ToString() {
+            return _variant switch {
+            0 => "Ok",
+            1 => "Err",
+            2 => "Panic",
+            3 => "Null",
+            _ => throw new InteropException()
+            };
+        }
 
         public ref struct Marshaller
         {


### PR DESCRIPTION
There has been a change from `0.14.0` to `0.15.0` that adds support for stateful enums, which is awesome but it make some QOL functions such as `ToString` go away, and forces C# embedders to roll their own implementation for each type. This PR is a suggested naive implementation of a `ToString` generation for enum types for C#.

Please lmk if there are any tests/other changes you'd like me to add, and thank you for all your work!