### PR TITLE
Remove eprintln! calls from C# bindgen

### DIFF
--- a/crates/backend_csharp/src/interop/patterns/callbacks.rs
+++ b/crates/backend_csharp/src/interop/patterns/callbacks.rs
@@ -24,8 +24,6 @@ pub fn write_type_definition_named_callback(i: &Interop, w: &mut IndentWriter, t
         params_native.push(format!("{} {}", i.to_native_callback_typespecifier(param.the_type()), param.name()));
         params_invoke.push(param_to_managed(param));
     }
-    eprintln!("params_native: {params_native:?}");
-    eprintln!("rval_unsafe: {rval_unsafe}");
     params.pop();
     params_invoke.pop();
 


### PR DESCRIPTION
We generate bindings as part of our build process, and we noticed that after syncing to latest `master` we started seeing some undesired prints. Judging by the [commit](https://github.com/ralfbiedert/interoptopus/commit/511bffab535b76fe5ff20bc5c167ca3bd1945649) message, I assume it's a debugging leftover. Can we remove it?