### PR TITLE
✨ Regen mode

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,2 @@
+update-bindings $INTEROPTOPUS_UPDATE_BINDINGS="1":
+    cargo test

--- a/tests/src/backend_c.rs
+++ b/tests/src/backend_c.rs
@@ -29,7 +29,7 @@ pub fn compile_c_app_if_installed(_app: impl AsRef<Path>) -> Result<(), Error> {
 #[macro_export]
 macro_rules! compile_output_c {
     ($generated:expr) => {{
-        if !$crate::UPDATE_BINDINGS {
+        if std::env::var($crate::UPDATE_BINDINGS).is_ok() {
             let temp_dir = $crate::tempdir()?;
             let header_file = temp_dir.path().join("header.h");
             let c_file = temp_dir.path().join("app.c");

--- a/tests/src/backend_csharp.rs
+++ b/tests/src/backend_csharp.rs
@@ -32,10 +32,11 @@ pub fn compile_c_app_if_installed(_app: impl AsRef<Path>) -> Result<(), anyhow::
     Ok(())
 }
 
+// Not used!
 #[macro_export]
 macro_rules! compile_output_csharp {
     ($generated:expr) => {{
-        if !$crate::UPDATE_BINDINGS {
+        if std::env::var($crate::UPDATE_BINDINGS).is_ok() {
             let temp_dir = $crate::tempdir()?;
             let header_file = temp_dir.path().join("header.h");
             let c_file = temp_dir.path().join("app.c");

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,15 +4,15 @@ pub mod backend_csharp;
 
 pub use tempfile::tempdir;
 
-/// Set this to `true` if you want to update bindings.
-pub static UPDATE_BINDINGS: bool = false;
+// Env variable, set it to any value to regenerate the bindings.
+pub const UPDATE_BINDINGS: &str = "INTEROPTOPUS_UPDATE_BINDINGS";
 
 #[macro_export]
 macro_rules! validate_output {
     ($folder:expr, $file:expr, $generated:expr) => {
         let file = format!("{}/{}", $folder, $file);
 
-        if $crate::UPDATE_BINDINGS {
+        if std::env::var($crate::UPDATE_BINDINGS).is_ok() {
             ::std::fs::write(file, $generated).unwrap();
         } else {
             let expected = ::std::fs::read_to_string(file.clone())?;


### PR DESCRIPTION
Use `just update-bindings`  or run cargo test with INTEROPTOPUS_UPDATE_BINDINGS environment variable set (to any value) to regenerate library bindings.

This replaces the old UPDATE_BINDINGS static boolean and you do not need to change any sources and risk accidentally commiting wrong setting.