### PR TITLE
Extended Inventory manipulation.

### DIFF
--- a/crates/backend_c/src/converters.rs
+++ b/crates/backend_c/src/converters.rs
@@ -58,7 +58,7 @@ pub fn to_type_specifier(g: &Interop, x: &Type) -> String {
         Type::Primitive(x) => primitive_to_typename(*x),
         Type::Enum(x) => enum_to_typename(g, x),
         Type::Opaque(x) => opaque_to_typename(g, x),
-        Type::ExternType(name) => name.clone(),
+        Type::Included(included) => included.name().to_string(),
         Type::Composite(x) => composite_to_typename(g, x),
         Type::Wire(_) => "void *".to_string(),        // TODO
         Type::WirePayload(_) => "void *".to_string(), // TODO

--- a/crates/backend_c/src/converters.rs
+++ b/crates/backend_c/src/converters.rs
@@ -58,6 +58,7 @@ pub fn to_type_specifier(g: &Interop, x: &Type) -> String {
         Type::Primitive(x) => primitive_to_typename(*x),
         Type::Enum(x) => enum_to_typename(g, x),
         Type::Opaque(x) => opaque_to_typename(g, x),
+        Type::ExternType(name) => name.clone(),
         Type::Composite(x) => composite_to_typename(g, x),
         Type::Wire(_) => "void *".to_string(),        // TODO
         Type::WirePayload(_) => "void *".to_string(), // TODO

--- a/crates/backend_c/src/docs.rs
+++ b/crates/backend_c/src/docs.rs
@@ -35,7 +35,7 @@ impl<'a> Markdown<'a> {
             Type::Array(_) => return Ok(()),
             Type::Enum(e) => e.meta(),
             Type::Opaque(o) => o.meta(),
-            Type::ExternType(_) => return Ok(()),
+            Type::Included(_) => return Ok(()),
             Type::Composite(c) => c.meta(),
             Type::Wire(_) => todo!(),
             Type::WirePayload(_) => todo!(),

--- a/crates/backend_c/src/docs.rs
+++ b/crates/backend_c/src/docs.rs
@@ -35,6 +35,7 @@ impl<'a> Markdown<'a> {
             Type::Array(_) => return Ok(()),
             Type::Enum(e) => e.meta(),
             Type::Opaque(o) => o.meta(),
+            Type::ExternType(_) => return Ok(()),
             Type::Composite(c) => c.meta(),
             Type::Wire(_) => todo!(),
             Type::WirePayload(_) => todo!(),

--- a/crates/backend_c/src/interop.rs
+++ b/crates/backend_c/src/interop.rs
@@ -67,6 +67,8 @@ pub enum NameCase {
     Snake,
     /// Names in upper case with '_' as spacing e.g. '`THE_TYPE_NAME`'
     ShoutySnake,
+    /// Names in original form, no conversion applied.
+    Original,
 }
 
 pub trait ToNamingStyle {
@@ -88,6 +90,7 @@ impl ToNamingStyle for &str {
             NameCase::UpperCamel => self.to_upper_camel_case(),
             NameCase::Snake => self.to_snake_case(),
             NameCase::ShoutySnake => self.to_shouty_snake_case(),
+            NameCase::Original => self.to_string(),
         }
     }
 }

--- a/crates/backend_c/src/interop/types.rs
+++ b/crates/backend_c/src/interop/types.rs
@@ -31,8 +31,8 @@ pub fn write_type_definition(i: &Interop, w: &mut IndentWriter, the_type: &Type,
         Type::Opaque(o) => {
             write_type_definition_opaque(i, w, o)?;
         }
-        Type::ExternType(_) => {
-            // Extern types are assumed to be defined elsewhere.
+        Type::Included(_) => {
+            // Included types are assumed to be `included` via headers.
         }
         Type::Composite(c) => {
             write_type_definition_composite(i, w, c)?;

--- a/crates/backend_c/src/interop/types.rs
+++ b/crates/backend_c/src/interop/types.rs
@@ -31,6 +31,9 @@ pub fn write_type_definition(i: &Interop, w: &mut IndentWriter, the_type: &Type,
         Type::Opaque(o) => {
             write_type_definition_opaque(i, w, o)?;
         }
+        Type::ExternType(_) => {
+            // Extern types are assumed to be defined elsewhere.
+        }
         Type::Composite(c) => {
             write_type_definition_composite(i, w, c)?;
             w.newline()?;

--- a/crates/backend_c/src/lib.rs
+++ b/crates/backend_c/src/lib.rs
@@ -116,3 +116,38 @@ mod interop;
 
 pub use docs::Markdown;
 pub use interop::{DocStyle, EnumVariants, Functions, Indentation, Interop, InteropBuilder, NameCase};
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn is_included_verbatim() {
+        // Types which are marked as `Included` should be verbatim in the output.  I.e. they should
+        // not have the string modified in any way, including not changing the case.
+        use crate::Interop;
+        use interoptopus::inventory::{Inventory, Symbol};
+        use interoptopus::lang::{Enum, Function, Included, Meta, Representation, Signature, Type};
+
+        // Build a simple inventory.
+        let inventory = Inventory::builder()
+            .register(Symbol::Type(Type::Enum(Enum::new("included_t".into(), vec![], Meta::default(), Representation::default()))))
+            .register(Symbol::Function(Function::new(
+                "test".into(),
+                Signature::new(vec![], Type::Enum(Enum::new("included_t".into(), vec![], Meta::default(), Representation::default()))),
+                Meta::default(),
+                vec![],
+            )))
+            .validate()
+            .build()
+            // Change the type to be `Included` instead of `Enum`.
+            // If the user wants to follow interoptopus renaming from the configuration, they should
+            // run the name conversion on their own.
+            .replace_type("included_t", Type::Included(Included::new("included_t".into(), Meta::default())));
+
+        let config = Interop::builder().inventory(inventory).build().unwrap();
+        let content = config.to_string().unwrap();
+
+        assert!(content.contains("included_t"));
+        assert!(!content.contains("INCLUDED_T"));
+        assert!(!content.contains("enum"));
+    }
+}

--- a/crates/backend_cpython/src/converter.rs
+++ b/crates/backend_cpython/src/converter.rs
@@ -82,7 +82,7 @@ pub fn to_ctypes_name(the_type: &Type, with_type_annotations: bool) -> String {
         Type::WirePayload(_) => "todo".to_string(),
         Type::Array(x) => format!("{} * {}", to_ctypes_name(x.the_type(), with_type_annotations), x.len()),
         Type::Opaque(_) => "ERROR".to_string(),
-        Type::ExternType(_) => "ERROR".to_string(), // extern types are not supported in this backend
+        Type::Included(_) => "ERROR".to_string(), // included types are not supported in this backend
         Type::FnPointer(x) => fnpointer_to_typename(x),
         Type::ReadPointer(x) => match &**x {
             Type::Opaque(_) => "ctypes.c_void_p".to_string(),

--- a/crates/backend_cpython/src/converter.rs
+++ b/crates/backend_cpython/src/converter.rs
@@ -82,6 +82,7 @@ pub fn to_ctypes_name(the_type: &Type, with_type_annotations: bool) -> String {
         Type::WirePayload(_) => "todo".to_string(),
         Type::Array(x) => format!("{} * {}", to_ctypes_name(x.the_type(), with_type_annotations), x.len()),
         Type::Opaque(_) => "ERROR".to_string(),
+        Type::ExternType(_) => "ERROR".to_string(), // extern types are not supported in this backend
         Type::FnPointer(x) => fnpointer_to_typename(x),
         Type::ReadPointer(x) => match &**x {
             Type::Opaque(_) => "ctypes.c_void_p".to_string(),

--- a/crates/backend_csharp/src/converter.rs
+++ b/crates/backend_csharp/src/converter.rs
@@ -40,6 +40,7 @@ pub fn field_to_type(x: &Type) -> String {
         Type::Array(a) => format!("{}[]", field_to_type(a.the_type())),
         Type::Enum(x) => x.rust_name().to_string(),
         Type::Opaque(_) => "IntPtr".to_string(),
+        Type::ExternType(name) => name.clone(),
         Type::Composite(x) => x.rust_name().to_string(),
         Type::Wire(x) => x.rust_name().to_string(),
         Type::WirePayload(dom) => match dom {
@@ -79,6 +80,7 @@ pub fn field_to_type_unmanaged(x: &Type) -> String {
         Type::Array(x) => field_to_type(x.the_type()),
         Type::Enum(x) => format!("{}.Unmanaged", x.rust_name()),
         Type::Opaque(_) => "TODO".to_string(),
+        Type::ExternType(_) => "TODO".to_string(),
         Type::Composite(x) => format!("{}.Unmanaged", x.rust_name()),
         Type::Wire(x) => format!("WireOf{}", x.rust_name()),
         Type::WirePayload(_) => todo!(),
@@ -128,6 +130,7 @@ pub fn param_to_type(x: &Type) -> String {
         Type::Array(_) => todo!(),
         Type::Enum(x) => x.rust_name().to_string(),
         Type::Opaque(_) => "IntPtr".to_string(),
+        Type::ExternType(name) => name.clone(),
         Type::Composite(x) => x.rust_name().to_string(),
         Type::Wire(x) => format!("WireOf{}", x.rust_name()),
         Type::WirePayload(_) => todo!(),
@@ -240,6 +243,7 @@ pub fn rval_to_type_sync(x: &Type) -> String {
         Type::Array(_) => todo!(),
         Type::Enum(x) => x.rust_name().to_string(),
         Type::Opaque(_) => "IntPtr".to_string(),
+        Type::ExternType(name) => name.clone(),
         Type::Composite(x) => x.rust_name().to_string(),
         Type::Wire(x) => format!("WireOf{}", x.rust_name()),
         Type::WirePayload(_) => todo!(),
@@ -357,6 +361,7 @@ pub fn is_reusable(t: &Type) -> bool {
         }
         Type::FnPointer(_) => true,
         Type::Opaque(_) => false,
+        Type::ExternType(_) => false,
         Type::Primitive(_) => true,
         Type::ReadPointer(_) => true,
         Type::ReadWritePointer(_) => true,
@@ -406,6 +411,7 @@ pub fn has_dispose(t: &Type) -> bool {
         }
         Type::FnPointer(_) => false,
         Type::Opaque(_) => false,
+        Type::ExternType(_) => false, // extern types are never disposed
         Type::Primitive(_) => false,
         Type::ReadPointer(_) => false,
         Type::ReadWritePointer(_) => false,

--- a/crates/backend_csharp/src/converter.rs
+++ b/crates/backend_csharp/src/converter.rs
@@ -40,7 +40,7 @@ pub fn field_to_type(x: &Type) -> String {
         Type::Array(a) => format!("{}[]", field_to_type(a.the_type())),
         Type::Enum(x) => x.rust_name().to_string(),
         Type::Opaque(_) => "IntPtr".to_string(),
-        Type::ExternType(name) => name.clone(),
+        Type::Included(included) => included.name().to_string(),
         Type::Composite(x) => x.rust_name().to_string(),
         Type::Wire(x) => x.rust_name().to_string(),
         Type::WirePayload(dom) => match dom {
@@ -80,7 +80,7 @@ pub fn field_to_type_unmanaged(x: &Type) -> String {
         Type::Array(x) => field_to_type(x.the_type()),
         Type::Enum(x) => format!("{}.Unmanaged", x.rust_name()),
         Type::Opaque(_) => "TODO".to_string(),
-        Type::ExternType(_) => "TODO".to_string(),
+        Type::Included(_) => "TODO".to_string(),
         Type::Composite(x) => format!("{}.Unmanaged", x.rust_name()),
         Type::Wire(x) => format!("WireOf{}", x.rust_name()),
         Type::WirePayload(_) => todo!(),
@@ -130,7 +130,7 @@ pub fn param_to_type(x: &Type) -> String {
         Type::Array(_) => todo!(),
         Type::Enum(x) => x.rust_name().to_string(),
         Type::Opaque(_) => "IntPtr".to_string(),
-        Type::ExternType(name) => name.clone(),
+        Type::Included(included) => included.name().to_string(),
         Type::Composite(x) => x.rust_name().to_string(),
         Type::Wire(x) => format!("WireOf{}", x.rust_name()),
         Type::WirePayload(_) => todo!(),
@@ -243,7 +243,7 @@ pub fn rval_to_type_sync(x: &Type) -> String {
         Type::Array(_) => todo!(),
         Type::Enum(x) => x.rust_name().to_string(),
         Type::Opaque(_) => "IntPtr".to_string(),
-        Type::ExternType(name) => name.clone(),
+        Type::Included(included) => included.name().to_string(),
         Type::Composite(x) => x.rust_name().to_string(),
         Type::Wire(x) => format!("WireOf{}", x.rust_name()),
         Type::WirePayload(_) => todo!(),
@@ -361,7 +361,7 @@ pub fn is_reusable(t: &Type) -> bool {
         }
         Type::FnPointer(_) => true,
         Type::Opaque(_) => false,
-        Type::ExternType(_) => false,
+        Type::Included(_) => false,
         Type::Primitive(_) => true,
         Type::ReadPointer(_) => true,
         Type::ReadWritePointer(_) => true,
@@ -411,7 +411,7 @@ pub fn has_dispose(t: &Type) -> bool {
         }
         Type::FnPointer(_) => false,
         Type::Opaque(_) => false,
-        Type::ExternType(_) => false, // extern types are never disposed
+        Type::Included(_) => false, // included types are defined elsewhere.
         Type::Primitive(_) => false,
         Type::ReadPointer(_) => false,
         Type::ReadWritePointer(_) => false,

--- a/crates/backend_csharp/src/interop.rs
+++ b/crates/backend_csharp/src/interop.rs
@@ -354,7 +354,7 @@ impl Interop {
             Type::Array(_) => false,
             Type::Enum(x) => self.should_emit_by_meta(x.meta()),
             Type::Opaque(x) => self.should_emit_by_meta(x.meta()),
-            Type::ExternType(_) => false, // extern types are never emitted
+            Type::Included(_) => false, // included types are never emitted
             Type::Composite(x) => self.should_emit_by_meta(x.meta()),
             Type::Wire(x) => self.should_emit_by_meta(x.meta()),
             Type::WirePayload(dom) => match dom {

--- a/crates/backend_csharp/src/interop.rs
+++ b/crates/backend_csharp/src/interop.rs
@@ -354,6 +354,7 @@ impl Interop {
             Type::Array(_) => false,
             Type::Enum(x) => self.should_emit_by_meta(x.meta()),
             Type::Opaque(x) => self.should_emit_by_meta(x.meta()),
+            Type::ExternType(_) => false, // extern types are never emitted
             Type::Composite(x) => self.should_emit_by_meta(x.meta()),
             Type::Wire(x) => self.should_emit_by_meta(x.meta()),
             Type::WirePayload(dom) => match dom {

--- a/crates/backend_csharp/src/interop/types.rs
+++ b/crates/backend_csharp/src/interop/types.rs
@@ -38,7 +38,7 @@ pub fn write_type_definition(i: &Interop, w: &mut IndentWriter, the_type: &Type)
             w.newline()?;
         }
         Type::Opaque(_) => {}
-        Type::ExternType(_) => {} // Extern types are never emitted
+        Type::Included(_) => {} // Included types are never emitted
         Type::Composite(c) => {
             write_type_definition_composite(i, w, c)?;
             w.newline()?;

--- a/crates/backend_csharp/src/interop/types.rs
+++ b/crates/backend_csharp/src/interop/types.rs
@@ -38,6 +38,7 @@ pub fn write_type_definition(i: &Interop, w: &mut IndentWriter, the_type: &Type)
             w.newline()?;
         }
         Type::Opaque(_) => {}
+        Type::ExternType(_) => {} // Extern types are never emitted
         Type::Composite(c) => {
             write_type_definition_composite(i, w, c)?;
             w.newline()?;

--- a/crates/core/src/inventory/core.rs
+++ b/crates/core/src/inventory/core.rs
@@ -1,6 +1,6 @@
 use crate::inventory::forbidden::FORBIDDEN_NAMES;
 use crate::lang::util::{extract_namespaces_from_types, extract_wire_types_from_functions, holds_opaque_without_ref, types_from_functions_types};
-use crate::lang::{Constant, Function, Included, Parameter, Signature, Type};
+use crate::lang::{Constant, Function, Included, Meta, Opaque, Parameter, Signature, Type};
 use crate::pattern::LibraryPattern;
 use std::collections::HashSet;
 
@@ -442,6 +442,17 @@ impl Inventory {
                 }
             }
         }
+    }
+
+    /// Replace a composite type with an opaque one.
+    /// This is used in combination with `Included` types to prevent redefinitions of
+    /// structures which will be included.  In this case, we want them forward referenced
+    /// rather than completely ignored.
+    ///
+    /// TODO: should we also replace in functions?  Seems to be happy without that.
+    pub fn replace_with_opaque(self, name: &str) -> Self {
+        let new_type = Type::Opaque(Opaque::new(name.to_string(), Meta::default()));
+        self.replace_type(name, new_type)
     }
 
     /// Replace the named type with a new one.

--- a/crates/core/src/inventory/core.rs
+++ b/crates/core/src/inventory/core.rs
@@ -457,14 +457,7 @@ impl Inventory {
 
     /// Mark (replace) a composite or enum type with an included one.
     pub fn mark_included(self, name: &str) -> Self {
-        self.filter_map(|item| {
-            match item {
-                OwnedInventoryItem::CType(t) if t.name_within_lib() == name => {
-                    Some(OwnedInventoryItem::Included(Included::new(t.name_within_lib(), Meta::default())))
-                }
-                _ => Some(item),
-            }
-        })
+        self.replace_type(name, Type::Included(Included::new(name.to_string(), Meta::default())))
     }
 
     /// Replace the named type with a new one.

--- a/crates/core/src/inventory/core.rs
+++ b/crates/core/src/inventory/core.rs
@@ -448,8 +448,6 @@ impl Inventory {
     /// This is used in combination with `Included` types to prevent redefinitions of
     /// structures which will be included.  In this case, we want them forward referenced
     /// rather than completely ignored.
-    ///
-    /// TODO: should we also replace in functions?  Seems to be happy without that.
     pub fn mark_opaque(self, name: &str) -> Self {
         let new_type = Type::Opaque(Opaque::new(name.to_string(), Meta::default()));
         self.replace_type(name, new_type)

--- a/crates/core/src/inventory/mod.rs
+++ b/crates/core/src/inventory/mod.rs
@@ -60,13 +60,15 @@ pub fn merge_inventories(inventories: &[Inventory]) -> Inventory {
     let mut constants = Vec::new();
     let mut patterns = Vec::new();
     let mut types = Vec::new();
+    let mut extern_types = Vec::new();
 
     for inventory in inventories {
         functions.extend_from_slice(inventory.functions());
         constants.extend_from_slice(inventory.constants());
         patterns.extend_from_slice(inventory.patterns());
         types.extend_from_slice(inventory.c_types());
+        extern_types.extend_from_slice(inventory.extern_types());
     }
 
-    Inventory::new(functions, constants, patterns, types.as_slice())
+    Inventory::new(functions, constants, patterns, types.as_slice(), extern_types)
 }

--- a/crates/core/src/inventory/mod.rs
+++ b/crates/core/src/inventory/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod core;
 pub(crate) mod forbidden;
 
 use crate::lang::Function;
-pub use core::{Inventory, InventoryBuilder, InventoryItem, Symbol};
+pub use core::{Inventory, InventoryBuilder, InventoryItem, OwnedInventoryItem, Symbol};
 
 /// Returns all functions not belonging to a [`service`](crate::pattern::service) pattern.
 ///

--- a/crates/core/src/lang/included.rs
+++ b/crates/core/src/lang/included.rs
@@ -1,0 +1,28 @@
+use crate::lang::Meta;
+
+/// An included type only known by name.
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct Included {
+    name: String,
+    meta: Meta,
+}
+
+impl Included {
+    /// Create a new included type.
+    #[must_use]
+    pub const fn new(name: String, meta: Meta) -> Self {
+        Self { name, meta }
+    }
+
+    /// Get the name of the included type.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the meta information of the included type.
+    #[must_use]
+    pub const fn meta(&self) -> &Meta {
+        &self.meta
+    }
+}

--- a/crates/core/src/lang/mod.rs
+++ b/crates/core/src/lang/mod.rs
@@ -15,6 +15,7 @@ pub use constant::{Constant, ConstantValue};
 pub use enums::{Enum, Variant, VariantKind};
 pub use fnpointer::FnPointer;
 pub use function::{Function, Parameter, Signature, SugaredReturnType};
+pub use included::Included;
 pub use info::{ConstantInfo, FunctionInfo, TypeInfo};
 pub use meta::{Docs, Meta, Visibility};
 pub use namespace::NamespaceMappings;
@@ -27,6 +28,7 @@ mod constant;
 mod enums;
 mod fnpointer;
 mod function;
+mod included;
 mod info;
 mod meta;
 mod namespace;
@@ -58,7 +60,7 @@ pub enum Type {
     /// useful to higher level languages.
     Pattern(TypePattern),
     /// A type only known by name expected to be defined elsewhere and included.
-    ExternType(String),
+    Included(Included),
 }
 
 /// The type contained inside a [`Wire`](crate::wire::Wire).
@@ -150,7 +152,7 @@ impl Type {
                 _ => x.fallback_type().name_within_lib(),
             },
             Self::Array(x) => x.rust_name(),
-            Self::ExternType(name) => name.clone(),
+            Self::Included(included) => included.name().to_string(),
         }
     }
 
@@ -180,7 +182,7 @@ impl Type {
             Self::ReadWritePointer(x) => Some(x.as_ref()),
             Self::Pattern(_) => None,
             Self::Array(_) => None,
-            Self::ExternType(_) => None,
+            Self::Included(_) => None,
         }
     }
 

--- a/crates/core/src/lang/mod.rs
+++ b/crates/core/src/lang/mod.rs
@@ -57,6 +57,8 @@ pub enum Type {
     /// Special patterns with primitives existing on C-level but special semantics.
     /// useful to higher level languages.
     Pattern(TypePattern),
+    /// A type only known by name expected to be defined elsewhere and included.
+    ExternType(String),
 }
 
 /// The type contained inside a [`Wire`](crate::wire::Wire).
@@ -148,6 +150,7 @@ impl Type {
                 _ => x.fallback_type().name_within_lib(),
             },
             Self::Array(x) => x.rust_name(),
+            Self::ExternType(name) => name.clone(),
         }
     }
 
@@ -177,6 +180,7 @@ impl Type {
             Self::ReadWritePointer(x) => Some(x.as_ref()),
             Self::Pattern(_) => None,
             Self::Array(_) => None,
+            Self::ExternType(_) => None,
         }
     }
 

--- a/crates/core/src/lang/util.rs
+++ b/crates/core/src/lang/util.rs
@@ -278,7 +278,7 @@ fn types_from_type_recursive_inner(start: &Type, types: &mut HashSet<Type>, choi
             TypePattern::APIVersion => {}
             TypePattern::Utf8String(_) => {}
         },
-        Type::ExternType(_) => { /* Nothing to do */ }
+        Type::Included(_) => { /* Nothing to do */ }
     }
 }
 
@@ -362,7 +362,7 @@ pub(crate) fn extract_namespaces_from_types(types: &[Type], into: &mut HashSet<S
                     into.insert(x.meta().module().to_string());
                 }
             },
-            Type::ExternType(_) => { /* Nothing to do */ }
+            Type::Included(_) => { /* Nothing to do */ }
         }
     }
 }
@@ -422,7 +422,7 @@ pub(crate) fn holds_opaque_without_ref(typ: &Type) -> bool {
             TypePattern::AsyncCallback(_) => false,
             TypePattern::Vec(x) => holds_opaque_without_ref(x.t()),
         },
-        Type::ExternType(_) => true /* ? think so ? */,
+        Type::Included(_) => true, /* TODO: ? think so ? */
     }
 }
 
@@ -508,7 +508,7 @@ pub fn is_global_type(t: &Type) -> bool {
             TypePattern::Utf8String(_) => true,
             TypePattern::Vec(x) => is_global_type(x.t()),
         },
-        Type::ExternType(_) => true,
+        Type::Included(_) => true,
     }
 }
 

--- a/crates/core/src/lang/util.rs
+++ b/crates/core/src/lang/util.rs
@@ -508,7 +508,7 @@ pub fn is_global_type(t: &Type) -> bool {
             TypePattern::Utf8String(_) => true,
             TypePattern::Vec(x) => is_global_type(x.t()),
         },
-        Type::Included(_) => false,
+        Type::Included(_) => true,
     }
 }
 

--- a/crates/core/src/lang/util.rs
+++ b/crates/core/src/lang/util.rs
@@ -508,7 +508,7 @@ pub fn is_global_type(t: &Type) -> bool {
             TypePattern::Utf8String(_) => true,
             TypePattern::Vec(x) => is_global_type(x.t()),
         },
-        Type::Included(_) => true,
+        Type::Included(_) => false,
     }
 }
 

--- a/crates/core/src/lang/util.rs
+++ b/crates/core/src/lang/util.rs
@@ -278,6 +278,7 @@ fn types_from_type_recursive_inner(start: &Type, types: &mut HashSet<Type>, choi
             TypePattern::APIVersion => {}
             TypePattern::Utf8String(_) => {}
         },
+        Type::ExternType(_) => { /* Nothing to do */ }
     }
 }
 
@@ -361,6 +362,7 @@ pub(crate) fn extract_namespaces_from_types(types: &[Type], into: &mut HashSet<S
                     into.insert(x.meta().module().to_string());
                 }
             },
+            Type::ExternType(_) => { /* Nothing to do */ }
         }
     }
 }
@@ -420,6 +422,7 @@ pub(crate) fn holds_opaque_without_ref(typ: &Type) -> bool {
             TypePattern::AsyncCallback(_) => false,
             TypePattern::Vec(x) => holds_opaque_without_ref(x.t()),
         },
+        Type::ExternType(_) => true /* ? think so ? */,
     }
 }
 
@@ -505,6 +508,7 @@ pub fn is_global_type(t: &Type) -> bool {
             TypePattern::Utf8String(_) => true,
             TypePattern::Vec(x) => is_global_type(x.t()),
         },
+        Type::ExternType(_) => true,
     }
 }
 

--- a/crates/core/src/lang/util.rs
+++ b/crates/core/src/lang/util.rs
@@ -536,4 +536,5 @@ mod test {
         assert_eq!(Prettifier::from_rust_lower("hello_world").to_camel_case(), "HelloWorld");
         assert_eq!(Prettifier::from_rust_lower("single").to_camel_case(), "Single");
     }
+
 }


### PR DESCRIPTION
This PR extends Inventory manipulation and adds an addition to the NameCase.  It works for my use case but let me know if there are things to change and/or better approaches to the issue.  These items are intended to help deal with splitting headers into multiple files when you have elements which should be included rather than declared inline.  For instance, the most common use case for myself is to have the error type shared between multiple APIs meaning that while Rust knows the type, I want to put it in its own file and include it from all the others rather than having it redefined in each.

Additional item, the "Included" type is intentionally verbatim in regards to naming.  I.e. won't change the case or add underscores etc.  (As far as I could tell?)  This is needed in a number of my cases where the types come from 3rd party includes which don't follow my naming scheme and interopto was breaking things by changing the case.  I was tempted to pipe and optional override for this through 'Meta' but that seemed like a bit too much for a single PR.

If there is a better way to approach this, please let me know.  It was the best approach I could really think of without taking the risk of breaking other bits of the code.

Added Type::Included
  Provides a variation of opaque but in this case it is not forward declared, it is expected that it
  will be found in a using, include or other language specific manner.
Added NameCase::Original
  Tell interoptopus to not modify the case of names.  I would like to pipe this through as an optional
  meta override for everything eventually.  This is related to `Included` above as some types being
  included may come from a header which is not directly controlled and not everyone is totally consistent.
Added functionality to inventory.
  filter_map - Allows iteration over the inventory to filter the content and additionally modify it as desired.
    adds OwnedInventoryItem which is like InventoryItem but owns the content.
  mark_opaque - Simple helper to tell Interoptopus to treat a given type as opaque even if it has the full definition.
  mark_included - Simple helper to tell Interoptopus to treat a given type as included even if it has the full definition.
  insert - Add OwnedInventoryItems directly to the inventory, this is generally used by filter_map to auto sort the new
    items into the correct per-type vectors.
  replace_type - Replace a named type with a new type.  Iterates and replaces the items in types and function signatures.
    This is used by mark_opaque and mark_included but can be used directly as well.
