### PR TITLE
chore(release): Auto sync master to release after publishing a new release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.release-plz.outputs.releases != '[]'
         run: |
           git checkout master
-          git cherry-pick --allow-empty --empty=keep -x origin/release
+          git pull --ff-only origin release
           git push origin master
 
   release-plz-pr:


### PR DESCRIPTION
This will break if release/master diverge, but we always force push release to the latest release point - only after we start publishing backports this model needs to change.