### PR TITLE
chore: release v0.15.0-alpha.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/ralfbiedert/interoptopus"
 rust-version = "1.88"
-version = "0.15.0-alpha.15"
+version = "0.15.0-alpha.16"
 
 [workspace.dependencies]
 # Internal
-interoptopus = { path = "crates/core", version = "=0.15.0-alpha.15" }
-interoptopus_proc = { path = "crates/proc_macros", version = "=0.15.0-alpha.15" }
-interoptopus_backend_c = { path = "crates/backend_c", version = "=0.15.0-alpha.15" }
-interoptopus_backend_cpython = { path = "crates/backend_cpython", version = "=0.15.0-alpha.15" }
-interoptopus_backend_csharp = { path = "crates/backend_csharp", version = "=0.15.0-alpha.15" }
-interoptopus_backend_utils = { path = "crates/backend_utils", version = "=0.15.0-alpha.15" }
+interoptopus = { path = "crates/core", version = "=0.15.0-alpha.16" }
+interoptopus_proc = { path = "crates/proc_macros", version = "=0.15.0-alpha.16" }
+interoptopus_backend_c = { path = "crates/backend_c", version = "=0.15.0-alpha.16" }
+interoptopus_backend_cpython = { path = "crates/backend_cpython", version = "=0.15.0-alpha.16" }
+interoptopus_backend_csharp = { path = "crates/backend_csharp", version = "=0.15.0-alpha.16" }
+interoptopus_backend_utils = { path = "crates/backend_utils", version = "=0.15.0-alpha.16" }
 # Not published (no version dependency):
 interoptopus_reference_project = { path = "crates/reference_project" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,10 @@ derive_builder = "0.20.2"
 heck = "0.5.0"
 include_dir = { version = "0.7.4", features = ["glob"] }
 log = "0.4.27"
-proc-macro2 = "1.0.95"
 prettyplease = "0.2.35"
+proc-macro2 = "1.0.95"
 quote = "1.0.40"
+rustc-hash = { version = "2.1", default-features = false }
 serde = "1.0.219"
 syn = "2.0.104"
 tera = "1"

--- a/crates/backend_c/CHANGELOG.md
+++ b/crates/backend_c/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_c-v0.15.0-alpha.15...interoptopus_backend_c-v0.15.0-alpha.16)
+
+### ⚙️ Miscellaneous
+
+
+- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
+
+
 ## [0.15.0-alpha.15](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_c-v0.15.0-alpha.14...interoptopus_backend_c-v0.15.0-alpha.15)
 
 Bump interoptopus_proc.

--- a/crates/backend_c/Cargo.toml
+++ b/crates/backend_c/Cargo.toml
@@ -14,9 +14,8 @@ repository.workspace = true
 [lints]
 workspace = true
 
-
 [dependencies]
-interoptopus.workspace = true
-interoptopus_backend_utils.workspace = true
-heck = { workspace = true }
 derive_builder = { workspace = true }
+heck = { workspace = true }
+interoptopus = { workspace = true }
+interoptopus_backend_utils = { workspace = true }

--- a/crates/backend_cpython/CHANGELOG.md
+++ b/crates/backend_cpython/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_cpython-v0.15.0-alpha.15...interoptopus_backend_cpython-v0.15.0-alpha.16)
+
+### ⚙️ Miscellaneous
+
+
+- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
+
+
 ## [0.15.0-alpha.15](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_cpython-v0.15.0-alpha.14...interoptopus_backend_cpython-v0.15.0-alpha.15)
 
 Bump interoptopus_proc.

--- a/crates/backend_cpython/Cargo.toml
+++ b/crates/backend_cpython/Cargo.toml
@@ -15,8 +15,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-interoptopus.workspace = true
-interoptopus_backend_utils.workspace = true
 derive_builder = { workspace = true }
-tera.workspace = true
-include_dir.workspace = true
+include_dir = { workspace = true }
+interoptopus = { workspace = true }
+interoptopus_backend_utils = { workspace = true }
+tera = { workspace = true }

--- a/crates/backend_csharp/CHANGELOG.md
+++ b/crates/backend_csharp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_csharp-v0.15.0-alpha.15...interoptopus_backend_csharp-v0.15.0-alpha.16)
+
+### ⚙️ Miscellaneous
+
+
+- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
+
+
 ## [0.15.0-alpha.15](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_csharp-v0.15.0-alpha.14...interoptopus_backend_csharp-v0.15.0-alpha.15)
 
 Bump interoptopus_proc.

--- a/crates/backend_csharp/Cargo.toml
+++ b/crates/backend_csharp/Cargo.toml
@@ -15,10 +15,10 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-interoptopus.workspace = true
-interoptopus_backend_utils.workspace = true
-heck = { workspace = true }
 derive_builder = { workspace = true }
-tera.workspace = true
-include_dir.workspace = true
+heck = { workspace = true }
+include_dir = { workspace = true }
+interoptopus = { workspace = true }
+interoptopus_backend_utils = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tera = { workspace = true }

--- a/crates/backend_utils/CHANGELOG.md
+++ b/crates/backend_utils/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_utils-v0.15.0-alpha.15...interoptopus_backend_utils-v0.15.0-alpha.16)
+
+### ⚙️ Miscellaneous
+
+
+- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
+
+
 ## [0.15.0-alpha.15](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_utils-v0.15.0-alpha.14...interoptopus_backend_utils-v0.15.0-alpha.15)
 
 Bump interoptopus_proc.

--- a/crates/backend_utils/Cargo.toml
+++ b/crates/backend_utils/Cargo.toml
@@ -15,7 +15,5 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-interoptopus.workspace = true
+interoptopus = { workspace = true }
 tera = { workspace = true }
-
-

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus-v0.15.0-alpha.15...interoptopus-v0.15.0-alpha.16)
+
+### ⚙️ Miscellaneous
+
+
+- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
+
+
 ## [0.15.0-alpha.15](https://github.com/ralfbiedert/interoptopus/compare/interoptopus-v0.15.0-alpha.14...interoptopus-v0.15.0-alpha.15)
 
 Bump interoptopus_proc.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [features]
 default = ["derive"]
-derive = ["interoptopus_proc"]
+derive = ["dep:interoptopus_proc"]
 
 [dependencies]
 interoptopus_proc = { workspace = true, optional = true }
@@ -24,7 +24,7 @@ log = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
-rustc-hash = { version = "2.1", default-features = false }
+rustc-hash = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/proc_macros/CHANGELOG.md
+++ b/crates/proc_macros/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_proc-v0.15.0-alpha.15...interoptopus_proc-v0.15.0-alpha.16)
+
+### ⚙️ Miscellaneous
+
+
+- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
+
+
 ## [0.15.0-alpha.15](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_proc-v0.15.0-alpha.14...interoptopus_proc-v0.15.0-alpha.15)
 
 ### 🐛 Bug Fixes

--- a/crates/proc_macros/Cargo.toml
+++ b/crates/proc_macros/Cargo.toml
@@ -19,11 +19,11 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-proc-macro2.workspace = true
-prettyplease.workspace = true
+darling = { workspace = true }
+prettyplease = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["full", "visit-mut"] }
-quote.workspace = true
-darling.workspace = true
 
 [dev-dependencies]
 interoptopus = { path = "../core" } # only for macros doc-tests

--- a/crates/reference_project/Cargo.toml
+++ b/crates/reference_project/Cargo.toml
@@ -17,5 +17,5 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-interoptopus.workspace = true
+interoptopus = { workspace = true }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION



## 🤖 New release

* `interoptopus_proc`: 0.15.0-alpha.15 -> 0.15.0-alpha.16
* `interoptopus`: 0.15.0-alpha.15 -> 0.15.0-alpha.16 (✓ API compatible changes)
* `interoptopus_backend_utils`: 0.15.0-alpha.15 -> 0.15.0-alpha.16 (✓ API compatible changes)
* `interoptopus_backend_c`: 0.15.0-alpha.15 -> 0.15.0-alpha.16 (✓ API compatible changes)
* `interoptopus_backend_cpython`: 0.15.0-alpha.15 -> 0.15.0-alpha.16 (✓ API compatible changes)
* `interoptopus_backend_csharp`: 0.15.0-alpha.15 -> 0.15.0-alpha.16 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `interoptopus_proc`

<blockquote>

## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_proc-v0.15.0-alpha.15...interoptopus_proc-v0.15.0-alpha.16)

### ⚙️ Miscellaneous


- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
</blockquote>

## `interoptopus`

<blockquote>

## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus-v0.15.0-alpha.15...interoptopus-v0.15.0-alpha.16)

### ⚙️ Miscellaneous


- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
</blockquote>

## `interoptopus_backend_utils`

<blockquote>

## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_utils-v0.15.0-alpha.15...interoptopus_backend_utils-v0.15.0-alpha.16)

### ⚙️ Miscellaneous


- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
</blockquote>

## `interoptopus_backend_c`

<blockquote>

## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_c-v0.15.0-alpha.15...interoptopus_backend_c-v0.15.0-alpha.16)

### ⚙️ Miscellaneous


- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
</blockquote>

## `interoptopus_backend_cpython`

<blockquote>

## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_cpython-v0.15.0-alpha.15...interoptopus_backend_cpython-v0.15.0-alpha.16)

### ⚙️ Miscellaneous


- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
</blockquote>

## `interoptopus_backend_csharp`

<blockquote>

## [0.15.0-alpha.16](https://github.com/ralfbiedert/interoptopus/compare/interoptopus_backend_csharp-v0.15.0-alpha.15...interoptopus_backend_csharp-v0.15.0-alpha.16)

### ⚙️ Miscellaneous


- Streamline workspace dependencies - ([2a23a99](https://github.com/ralfbiedert/interoptopus/commit/2a23a9975a5235703ac5ffc1df46c8d27763fb3d))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).