### PR TITLE
Add Missing Zero-Arguments `impl_fnptr!`

### DIFF
--- a/crates/core/src/lang/types/fnptr.rs
+++ b/crates/core/src/lang/types/fnptr.rs
@@ -182,6 +182,7 @@ macro_rules! impl_fnptr {
         }
     };
 }
+impl_fnptr!(R);
 impl_fnptr!(R, T1);
 impl_fnptr!(R, T1, T2);
 impl_fnptr!(R, T1, T2, T3);


### PR DESCRIPTION
Noticed an odd omission while working on a project and it seemed like an easy fix.

I haven't checked that the generated code works properly, but I assume this was just a mistake since the macro already had support for zero args.