### PR TITLE
fix(csharp): emit AsUnmanaged() on blittable slice bindings

### DIFF
--- a/crates/backend_csharp/templates/rust/pattern/slice/fast.cs
+++ b/crates/backend_csharp/templates/rust/pattern/slice/fast.cs
@@ -98,6 +98,10 @@ public partial class {{ name }} : IEnumerable<{{ element_type }}>, IDisposable
         return unmanaged;
     }
 
+    {{ _fns_decorators_all | indent }}
+    {{ _fns_decorators_internal | indent }}
+    internal Unmanaged AsUnmanaged() => ToUnmanaged();
+
     [CustomMarshaller(typeof({{ name }}), MarshalMode.Default, typeof(Marshaller))]
     private struct MarshallerMeta { }
 

--- a/crates/backend_csharp/tests/reference_project/snapshots/r#mod__reference_project__interop.snap
+++ b/crates/backend_csharp/tests/reference_project/snapshots/r#mod__reference_project__interop.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42eed92662d488ad5865f54398736cd4691e2aee05adc59b704ceaad3058dca2
-size 827087
+oid sha256:56c84b66422084bc4c90b886f4e8ee83e961ad6e79568dfb9e29fda1ed6853de
+size 832913

--- a/crates/reference_project/src/lib.rs
+++ b/crates/reference_project/src/lib.rs
@@ -154,6 +154,7 @@ pub fn inventory() -> RustInventory {
         // .register(function!(patterns::slice::pattern_ffi_slice_7))
         .register(function!(patterns::slice::pattern_ffi_slice_8))
         .register(function!(patterns::slice::pattern_ffi_slice_9))
+        .register(function!(patterns::slice::pattern_ffi_slice_in_struct))
         .register(function!(patterns::slice::pattern_ffi_slice_delegate))
         .register(function!(patterns::slice::pattern_ffi_slice_delegate_huge))
         .register(function!(patterns::option::pattern_ffi_option_1))

--- a/crates/reference_project/src/patterns/slice.rs
+++ b/crates/reference_project/src/patterns/slice.rs
@@ -87,3 +87,16 @@ pub fn pattern_ffi_slice_8(slice: &SliceMut<CharArray>, callback: CallbackCharAr
 pub fn pattern_ffi_slice_9(slice: Slice<UseString>) -> ffi::String {
     slice.as_slice()[0].s1.clone()
 }
+
+/// A composite embedding a blittable `Slice<u8>`. Its generated `AsUnmanaged()`
+/// calls `bytes.AsUnmanaged()`, so the `SliceByte` binding must expose that method.
+#[ffi]
+#[derive(Clone)]
+pub struct UseSliceByteInStruct<'a> {
+    pub bytes: ffi::Slice<'a, u8>,
+}
+
+#[ffi]
+pub fn pattern_ffi_slice_in_struct(x: UseSliceByteInStruct) -> u32 {
+    x.bytes.as_slice().len() as u32
+}


### PR DESCRIPTION
Fixes #286.

## Problem

The C# backend emits `AsUnmanaged()` bodies on composite types (structs / tagged enums) that call `.AsUnmanaged()` on their embedded slice fields, but the blittable-element slice template never emits `AsUnmanaged()` on the slice class itself. A composite embedding e.g. `Slice<u8>` therefore generates `bytes.AsUnmanaged()` against a `SliceByte` that only defines `ToUnmanaged()`, failing to compile with `CS1061`.

Minimal public reproduction: https://github.com/sandersaares/whatiswrongwithyourdog-interoptopus-asunmanaged-tounmanaged

## Root cause

`templates/rust/pattern/slice/marshalling.cs` (used for non-blittable element types) already defines `internal Unmanaged AsUnmanaged() => ToUnmanaged();`, but `templates/rust/pattern/slice/fast.cs` (used for blittable element types — `SliceByte`, `SliceU32`, `SliceVec3f32`, …) defined only `ToUnmanaged()`. The two templates were asymmetric.

## Fix

Add `AsUnmanaged() => ToUnmanaged()` to `fast.cs`, mirroring `marshalling.cs`. For a borrowed slice the two are semantically identical — neither frees the backing buffer.

## Regression coverage

`reference_project` previously had no composite embedding a *blittable* slice, so the dotnet compile gate never exercised this path — which is why the broken codegen shipped uncaught. This PR adds a `UseSliceByteInStruct { bytes: Slice<u8> }` type plus a `pattern_ffi_slice_in_struct` function, so the generated `SliceByte.AsUnmanaged()` is now compiled by `Tests.csproj`.

I verified the guard works in both directions: reverting the `fast.cs` change reintroduces `CS1061` (and fails the snapshot assertion); with the change, `cargo test -p interoptopus_csharp --all-features` and `dotnet build .../Tests/Tests.csproj` both pass.
