### PR TITLE
fix: suppress clippy::too_many_arguments in callback! macro

### DIFF
--- a/crates/core/src/pattern/callback.rs
+++ b/crates/core/src/pattern/callback.rs
@@ -164,11 +164,17 @@ macro_rules! callback {
             }
 
             /// Will call function if it exists, panic otherwise.
+            // The generated signature mirrors the user's callback, which may have more
+            // parameters than the `too_many_arguments` lint allows. The shape is dictated
+            // by the FFI boundary, so suppress the lint on this generated method.
+            #[allow(clippy::too_many_arguments)]
             pub fn call(&self, $($param: $ty),*) -> $rval {
                 self.callback.expect("Assumed function would exist but it didn't.")($($param,)* self.data)
             }
 
             /// Will call function only if it exists
+            // See `call` above: the parameter count is dictated by the user's callback.
+            #[allow(clippy::too_many_arguments)]
             pub fn call_if_some(&self, $($param: $ty,)*) -> ::std::option::Option<$rval> {
                 match self.callback {
                     Some(c) => Some(c($($param,)* self.data)),

--- a/crates/core/tests/callbacks.rs
+++ b/crates/core/tests/callbacks.rs
@@ -68,3 +68,16 @@ fn drop_noop_on_fn_ptr_callback() {
     let cb = Noop2 { callback: Some(nothing), data: std::ptr::null(), destructor: None };
     drop(cb); // must not crash or double-free
 }
+
+// A callback whose parameter count exceeds clippy's `too_many_arguments` threshold (7)
+// must lint cleanly and work. The generated `call` / `call_if_some` methods take `&self`
+// plus every parameter, so without the in-macro `#[allow(clippy::too_many_arguments)]`
+// this 7-parameter callback would trip the lint from inside the macro.
+#[test]
+fn wide_callback_with_many_params() {
+    callback!(Wide(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32) -> i32);
+
+    let cb = Wide::from_fn(|a, b, c, d, e, f, g| a + b + c + d + e + f + g);
+    assert_eq!(cb.call(1, 2, 3, 4, 5, 6, 7), 28);
+    assert_eq!(cb.call_if_some(1, 2, 3, 4, 5, 6, 7), Some(28));
+}


### PR DESCRIPTION
## Problem

Defining a callback with the `callback!` macro that has **7 or more parameters** makes Clippy emit `clippy::too_many_arguments` errors that point at the user's `callback!(...)` invocation, even though the offending code is generated entirely inside the macro. This is a common shape when bridging to a .NET delegate that takes many arguments.

The macro generates inherent methods `call(&self, ...)` and `call_if_some(&self, ...)` that take `&self` plus every callback parameter. Clippy counts `&self`, so the lint fires once `1 + N > 7`, i.e. **N >= 7 parameters**. The generated `extern "C"` trampoline also has many arguments but Clippy intentionally skips non-Rust-ABI functions, so only `call` / `call_if_some` are flagged.

Because the lint is in Clippy's `complexity` group (default threshold 7), any project that denies `complexity` or runs `cargo clippy -- -D warnings` fails to build, with no clean fix at the call site since the user cannot annotate code they did not write.

Observed boundary:

| Parameters | `call` args (incl. `&self`) | Lint fires? |
|-----------:|-------------------------------:|:-----------:|
| 6          | 7                              | no          |
| 7          | 8                              | yes         |
| 8          | 9                              | yes         |

## Is it really a problem?

One might say this is a legitimate "too many arguments" scenario and the user should simplify their callback. Still, posting this as Clippy warnings coming from macros feels wrong despite being theoretically appropriate here. I defer to maintainer's judgement on whether this change is desirable or not.

## Fix

Add `#[allow(clippy::too_many_arguments)]` to the generated `call` / `call_if_some` methods inside the `callback!` macro, so downstream users are not penalized for the macro's generated signatures.

## Tests

A behavioral test in `crates/core/tests/callbacks.rs` exercises `from_fn` / `call` / `call_if_some` with a 7-parameter callback (which also trips the lint without the fix).

## Note

While investigating, I found that the repo's `just lint` runs `cargo clippy -- -D warnings` without `--all-targets`, so test code is not currently clippy-checked in CI. Extending lint coverage to test targets surfaces some pre-existing lint debt in feature-gated runtime code, so I've left that out of this PR; it can be addressed separately.