### PR TITLE
test: Mark test projects as AOT compatible and switch to xunit.v3.aot with MTP testrunner 

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ test-dotnet:
     # Make sure the DLL + Interop files exist
     cargo build -p reference_project  --all-features
     cargo test --test mod reference_project::interop  --all-features
-    dotnet test crates/backend_csharp/tests/reference_project/Tests/Tests.csproj
+    dotnet test --project crates/backend_csharp/tests/reference_project/Tests/Tests.csproj
 
 # Runs .NET benchmarks.
 bench-dotnet:
@@ -79,4 +79,4 @@ test-agent:
     # Agents: Feel free to update the test logic here for the task at hand.
     cargo build -p reference_project --all-features
     cargo test -p interoptopus_csharp --test mod reference_project::interop --all-features
-    dotnet test crates/backend_csharp/tests/reference_project/Tests/Tests.csproj
+    dotnet test --project crates/backend_csharp/tests/reference_project/Tests/Tests.csproj

--- a/crates/backend_csharp/tests/reference_project/Bindings/Bindings.csproj
+++ b/crates/backend_csharp/tests/reference_project/Bindings/Bindings.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\..\..\..\..\target\debug\*reference_project*">

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Arrays.Basic.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Arrays.Basic.cs
@@ -21,11 +21,11 @@ public class TestArrayBasic
     [InlineData(new byte[] { 1, 2, 3 })]
     [InlineData(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 })]
     [InlineData(null)]
-    public void array_1_throws(byte[] array)
+    public void array_1_throws(byte[]? array)
     {
         Assert.Throws<InvalidOperationException>(() => Interop.array_1(new Array
         {
-            data = array
+            data = array!
         }));
     }
 

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Arrays.Nested.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Arrays.Nested.cs
@@ -18,7 +18,7 @@ public class TestArrayNested
             y = 2.0f,
             z = 3.0f
         }, result.field_vec);
-        Assert.Equal(true, result.field_bool.Is);
+        Assert.True(result.field_bool.Is);
         Assert.Equal(42, result.field_int);
         Assert.Equal(Enumerable.Range(1, 5).Select(i => (ushort)i).ToArray(), result.field_array);
         Assert.Equal(Enumerable.Range(1, 16).Select(i => (byte)i).ToArray(), result.field_struct.data);
@@ -36,7 +36,7 @@ public class TestArrayNested
             y = 2.0f,
             z = 3.0f
         }, result.field_vec);
-        Assert.Equal(true, result.field_bool.Is);
+        Assert.True(result.field_bool.Is);
         Assert.Equal(42, result.field_int);
         Assert.Equal(Enumerable.Range(1, 5).Select(i => (ushort)i).ToArray(), result.field_array);
         Assert.Equal(Enumerable.Range(1, 16).Select(i => (byte)i).ToArray(), result.field_struct.data);

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Behavior.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Behavior.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using My.Company;
 using Xunit;
@@ -5,23 +7,16 @@ using Interop = My.Company.Interop;
 
 public class TestBehavior
 {
-    [Fact]
+    public static bool SupportsSehPanicBoundary =>
+        OperatingSystem.IsWindows() && RuntimeFeature.IsDynamicCodeSupported;
+
+    [Fact(
+        Skip = "Requires a runtime that exposes Rust panics as catchable SEH exceptions (only managed windows).",
+        SkipUnless = nameof(SupportsSehPanicBoundary)
+    )]
     public void behavior_panics()
     {
-        // We must only run this on Windows as SEH is only supported there. On Linux this would abort the process
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return;
-
-        try
-        {
-            Interop.behavior_panics();
-        }
-        catch (SEHException)
-        {
-            return;
-        }
-
-        Assert.True(false);
+        Assert.Throws<SEHException>(Interop.behavior_panics);
     }
 
     [Fact]

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Primitives.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Primitives.cs
@@ -1,4 +1,3 @@
-using My.Company;
 using My.Company.Common;
 using Xunit;
 using Interop = My.Company.Interop;

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Refs.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Core.Refs.cs
@@ -28,7 +28,7 @@ public class TestRefs
     {
         var x = 123L;
         var rval = Interop.ref3(ref x);
-        Assert.Equal(true, rval.Is);
+        Assert.True(rval.Is);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class TestRefs
     {
         var x = 123L;
         var rval = Interop.ref4(ref x).Is;
-        Assert.Equal(true, rval);
+        Assert.True(rval);
     }
 
     [Fact]

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Callbacks.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Callbacks.cs
@@ -42,7 +42,7 @@ public class TestPatternDelegates
     {
         using var cb = new MyCallbackNamespaced(value => value);
         var y = Interop.pattern_callback_4(cb, 5);
-        Assert.Equal(y, 5u);
+        Assert.Equal(5u, y);
     }
 
     [Fact]
@@ -66,15 +66,15 @@ public class TestPatternDelegates
     {
         Interop.pattern_ffi_slice_delegate(x =>
         {
-            Assert.Equal(x.Count, 10);
-            Assert.Equal(x[0], 0);
-            Assert.Equal(x[5], 5);
+            Assert.Equal(10, x.Count);
+            Assert.Equal(0, x[0]);
+            Assert.Equal(5, x[5]);
 
             // Test IEnumerable using LINQ
             var arr = x.ToArray();
-            Assert.Equal(arr.Length, 10);
-            Assert.Equal(arr[0], 0);
-            Assert.Equal(arr[5], 5);
+            Assert.Equal(10, arr.Length);
+            Assert.Equal(0, arr[0]);
+            Assert.Equal(5, arr[5]);
 
             return x[0];
         });
@@ -94,7 +94,7 @@ public class TestPatternDelegates
         ResultVoidError C1(int x, int y)
         {
             // This should see `6` here, and it does, because the function has set that value.
-            Assert.Equal(rval, 6);
+            Assert.Equal(6, rval);
             called_c1 = true;
 
             // However, when we now throw we would expect .NET to unwind that exception back
@@ -112,7 +112,7 @@ public class TestPatternDelegates
             // in particular that any code that you would expect to run in Rust subsequent to the invocation
             // of this callback (esp. `drop` code and friends) will NOT fire, leading to unexpected
             // memory loss or worse.
-            Assert.Equal(rval, 6);
+            Assert.Equal(6, rval);
             called_c2 = true;
             throw new Exception("Unchecked callback which we didn't handle. Comment this out and see the test fail.");
         }
@@ -134,7 +134,7 @@ public class TestPatternDelegates
             // If everything works Rust code after invoking C1 and C2 is still executed,
             // setting this variable to `8`.
             called_exception = true;
-            Assert.Equal(rval, 8);
+            Assert.Equal(8, rval);
         }
 
         Assert.True(called_c1);

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Basic.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Basic.cs
@@ -1,10 +1,11 @@
+using System.Threading.Tasks;
 using My.Company;
 using Xunit;
 
 public class TestPatternServicesAsyncBasic
 {
     [Fact]
-    public async void Create()
+    public async Task Create()
     {
         using var s = ServiceAsyncBasic.Simple();
     }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Cancel.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Cancel.cs
@@ -12,7 +12,7 @@ public class TestPatternServicesAsyncCancel
     public async Task LongRunningCompletesNormally()
     {
         using var s = ServiceAsyncCancel.Create();
-        var result = await s.LongRunning(5, 10);
+        var result = await s.LongRunning(5, 10, TestContext.Current.CancellationToken);
         Assert.Equal(5u, result);
     }
 
@@ -84,7 +84,7 @@ public class TestPatternServicesAsyncCancel
 
         // These tasks run with no cancellation and complete normally
         var normalTasks = Enumerable.Range(0, 3)
-            .Select(_ => s.LongRunning(3, 10))
+            .Select(_ => s.LongRunning(3, 10, TestContext.Current.CancellationToken))
             .ToArray();
 
         // Normal tasks should complete fine
@@ -107,7 +107,7 @@ public class TestPatternServicesAsyncCancel
         var task = s.CountingWork(200, 20, cts.Token);
 
         // Let it run for 500ms, then cancel
-        await Task.Delay(500);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<Exception>(async () => await task);
@@ -116,7 +116,7 @@ public class TestPatternServicesAsyncCancel
         var counterAtCancel = s.Counter();
 
         // Wait a bit and read again — should NOT have increased
-        await Task.Delay(500);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
         var counterAfterWait = s.Counter();
 
         Assert.True(counterAtCancel > 0);
@@ -137,7 +137,7 @@ public class TestPatternServicesAsyncCancel
         }
 
         // Service should still be usable after repeated cancellations
-        var result = await s.LongRunning(3, 10);
+        var result = await s.LongRunning(3, 10, TestContext.Current.CancellationToken);
         Assert.Equal(3u, result);
     }
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Ctor.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Ctor.cs
@@ -1,13 +1,14 @@
+using System.Threading.Tasks;
 using My.Company;
 using Xunit;
 
 public class TestPatternServicesAsyncCtor
 {
     [Fact]
-    public async void NewAsync()
+    public async Task NewAsync()
     {
         using var asyncBasic = ServiceAsyncBasic.Simple();
-        using var asyncCtor = await ServiceAsyncCtor.NewAsync(asyncBasic, 42);
+        using var asyncCtor = await ServiceAsyncCtor.NewAsync(asyncBasic, 42, TestContext.Current.CancellationToken);
         Assert.Equal(42u, asyncCtor.GetValue());
     }
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Panic.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Panic.cs
@@ -1,12 +1,11 @@
 using My.Company;
-using My.Company.Common;
 using System.Threading.Tasks;
 using Xunit;
 
 public class TestPatternServicesAsyncPanic
 {
     [Fact]
-    public async void PanickingThrowsException()
+    public async Task PanickingThrowsException()
     {
         using var s = ServiceAsyncPanic.Create();
 
@@ -15,34 +14,34 @@ public class TestPatternServicesAsyncPanic
         // turns into a TaskCanceledException on the .NET side.
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await s.Panicking();
+            await s.Panicking(TestContext.Current.CancellationToken);
         });
     }
 
     [Fact]
-    public async void NotPanickingSucceeds()
+    public async Task NotPanickingSucceeds()
     {
         using var s = ServiceAsyncPanic.Create();
-        await s.NotPanicking();
+        await s.NotPanicking(TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public async void ServiceWorksAfterPanic()
+    public async Task ServiceWorksAfterPanic()
     {
         using var s = ServiceAsyncPanic.Create();
 
         // First call panics
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await s.Panicking();
+            await s.Panicking(TestContext.Current.CancellationToken);
         });
 
         // Service is still functional after the panic
-        await s.NotPanicking();
+        await s.NotPanicking(TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public async void ServiceWorksAfterRepeatedPanics()
+    public async Task ServiceWorksAfterRepeatedPanics()
     {
         using var s = ServiceAsyncPanic.Create();
 
@@ -50,11 +49,11 @@ public class TestPatternServicesAsyncPanic
         {
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>
             {
-                await s.Panicking();
+                await s.Panicking(TestContext.Current.CancellationToken);
             });
         }
 
         // Service is still functional after repeated panics
-        await s.NotPanicking();
+        await s.NotPanicking(TestContext.Current.CancellationToken);
     }
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Result.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Result.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using My.Company;
 using My.Company.Common;
 using Xunit;
@@ -5,21 +6,21 @@ using Xunit;
 public class TestPatternServicesAsyncResult
 {
     [Fact]
-    public async void Success()
+    public async Task Success()
     {
         using var s = ServiceAsyncResult.Create();
-        await s.Success();
+        await s.Success(TestContext.Current.CancellationToken);
     }
 
     [Fact]
-    public async void Fail()
+    public async Task Fail()
     {
         var exceptionThrown = false;
         using var s = ServiceAsyncResult.Create();
 
         try
         {
-            await s.Fail();
+            await s.Fail(TestContext.Current.CancellationToken);
         }
         catch (EnumException<Error> e)
         {

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Rval.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Rval.cs
@@ -1,15 +1,16 @@
+using System.Threading.Tasks;
 using My.Company;
 using Xunit;
 
 public class TestPatternServicesAsyncRval
 {
     [Fact]
-    public async void Create()
+    public async Task Create()
     {
         using var s = ServiceAsyncRval.Simple();
-        Assert.Equal(123u, await s.Number());
-        Assert.Equal(new Vec3f32 { x = 0, y = 0, z = 0 }, await s.Vecf32());
-        Assert.Equal("hello", (await s.Wire()).Unwire());
+        Assert.Equal(123u, await s.Number(TestContext.Current.CancellationToken));
+        Assert.Equal(new Vec3f32 { x = 0, y = 0, z = 0 }, await s.Vecf32(TestContext.Current.CancellationToken));
+        Assert.Equal("hello", (await s.Wire(TestContext.Current.CancellationToken)).Unwire());
     }
 
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Shutdown.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Shutdown.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using My.Company;
 using Xunit;
-using Xunit.Abstractions;
 
 public class TestPatternServicesAsyncShutdown
 {
@@ -19,14 +15,14 @@ public class TestPatternServicesAsyncShutdown
             Assert.Null(SynchronizationContext.Current);
 
             var s = ServiceAsyncSleep.Create();
-            await s.ReturnAfterMs(0, 100);
+            await s.ReturnAfterMs(0, 100, TestContext.Current.CancellationToken);
             s.Dispose();
-        });
+        }, TestContext.Current.CancellationToken);
 
-        var winner = await Task.WhenAny(task, Task.Delay(5000));
+        var winner = await Task.WhenAny(task, Task.Delay(5000, TestContext.Current.CancellationToken));
         if (winner != task)
         {
-            Assert.True(false, "DEADLOCK DETECTED: await + Dispose without SyncContext hung for 5s");
+            Assert.Fail("DEADLOCK DETECTED: await + Dispose without SyncContext hung for 5s");
         }
 
         Assert.True(winner == task, "Deadlock: await + Dispose without SyncContext timed out after 5s");

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Sleep.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Sleep.cs
@@ -7,15 +7,15 @@ using Xunit;
 public class TestPatternServicesAsyncSleep
 {
     [Fact]
-    public async void ReturnAfterMs()
+    public async Task ReturnAfterMs()
     {
         using var s = ServiceAsyncSleep.Create();
-        var r = await s.ReturnAfterMs(123, 500);
-        Assert.Equal(r, 123u);
+        var r = await s.ReturnAfterMs(123, 500, TestContext.Current.CancellationToken);
+        Assert.Equal(123u, r);
     }
 
     [Fact]
-    public async void SupportsMultipleParallelCalls()
+    public async Task SupportsMultipleParallelCalls()
     {
         using var s = ServiceAsyncSleep.Create();
 
@@ -25,8 +25,8 @@ public class TestPatternServicesAsyncSleep
             var x = Random.Shared.Next(100, 1000);
             var ms = Random.Shared.Next(100, 1000);
 
-            var r = await s.ReturnAfterMs((ulong)x, (ulong)ms);
-            Assert.Equal((int)r, x);
+            var r = await s.ReturnAfterMs((ulong)x, (ulong)ms, TestContext.Current.CancellationToken);
+            Assert.Equal(x, (int)r);
         }).ToList();
 
         await Task.WhenAll(tasks);

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Structs.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Structs.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using My.Company;
 using Xunit;
 using Array = My.Company.Array;
@@ -6,7 +7,7 @@ using Array = My.Company.Array;
 public class TestPatternServicesAsyncStructs
 {
     [Fact]
-    public async void ProcessStruct()
+    public async Task ProcessStruct()
     {
         using var s = ServiceAsyncStructs.Create();
         var a = new NestedArray
@@ -22,7 +23,7 @@ public class TestPatternServicesAsyncStructs
                 data = new byte[16]
             }
         };
-        var r = await s.ProcessStruct(a);
-        Assert.Equal(r.field_int, 124);
+        var r = await s.ProcessStruct(a, TestContext.Current.CancellationToken);
+        Assert.Equal(124, r.field_int);
     }
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.VecString.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.VecString.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using My.Company;
 using My.Company.Common;
 using Xunit;
@@ -5,15 +6,15 @@ using Xunit;
 public class TestPatternServicesAsyncVecString
 {
     [Fact]
-    public async void HandleString()
+    public async Task HandleString()
     {
         using var s = ServiceAsyncVecString.Create();
-        var r = await s.HandleString("abc".Utf8());
-        Assert.Equal(r.IntoString(), "abc");
+        var r = await s.HandleString("abc".Utf8(), TestContext.Current.CancellationToken);
+        Assert.Equal("abc", r.IntoString());
     }
 
     [Fact]
-    public async void HandleVecString()
+    public async Task HandleVecString()
     {
         using var s = ServiceAsyncVecString.Create();
         var v = new[]
@@ -21,17 +22,17 @@ public class TestPatternServicesAsyncVecString
             "abc".Utf8()
         }.IntoVec();
 
-        var r = await s.HandleVecString(v);
-        Assert.Equal(r[0].IntoString(), "abc");
+        var r = await s.HandleVecString(v, TestContext.Current.CancellationToken);
+        Assert.Equal("abc", r[0].IntoString());
     }
 
 
     [Fact]
-    public async void HandleNestedString()
+    public async Task HandleNestedString()
     {
         using var s = ServiceAsyncVecString.Create();
-        var r = await s.HandleNestedString("abc".Utf8());
-        Assert.Equal(r.s1.IntoString(), "abc");
-        Assert.Equal(r.s2.IntoString(), "abc");
+        var r = await s.HandleNestedString("abc".Utf8(), TestContext.Current.CancellationToken);
+        Assert.Equal("abc", r.s1.IntoString());
+        Assert.Equal("abc", r.s2.IntoString());
     }
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Wire.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Async.Wire.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using My.Company;
 using My.Company.Common;
 using Xunit;
@@ -6,14 +7,14 @@ using Xunit;
 public class TestPatternServicesAsyncWire
 {
     [Fact]
-    public async void Passthrough()
+    public async Task Passthrough()
     {
         var s = ServiceAsyncWire.Create();
         var d = new Dictionary<string, string>
         {
             { "hello", "world" }
         };
-        var r = await s.WirePassthrough(d.Wire());
+        var r = await s.WirePassthrough(d.Wire(), TestContext.Current.CancellationToken);
         r.Unwire();
     }
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Callbacks.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Callbacks.cs
@@ -14,7 +14,7 @@ public class TestPatternServicesCallbacks
         callbacks.CallbackSimple(x =>
         {
             called = true;
-            Assert.Equal(x, 0u);
+            Assert.Equal(0u, x);
             return x;
         });
 
@@ -30,8 +30,8 @@ public class TestPatternServicesCallbacks
 
         callbacks.CallbackWithSlice((x, y) =>
         {
-            Assert.Equal(x, 1);
-            Assert.Equal(y, 2);
+            Assert.Equal(1, x);
+            Assert.Equal(2, y);
             called = true;
             return ResultVoidError.Ok;
         }, slice);

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Slices.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.Slices.cs
@@ -17,7 +17,7 @@ public class TestPatternServicesSlices
     {
         using var s = ServiceVariousSlices.Create();
         var slice = s.ReturnSlice();
-        Assert.Equal(slice.Count, 64);
+        Assert.Equal(64, slice.Count);
         Assert.Equal(123, (int)slice[0]);
         Assert.Equal(123, (int)slice[1]);
     }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.String.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Services.String.cs
@@ -34,6 +34,6 @@ public class TestPatternServicesString
     {
         using var s = ServiceStrings.Create();
         var result = s.ReturnCstr();
-        Assert.Equal(result, "hello.world");
+        Assert.Equal("hello.world", result);
     }
 }

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Slices.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Slices.cs
@@ -42,8 +42,8 @@ public class TestPatternSlices
             slice[1] = 100;
         });
 
-        Assert.Equal(data[0], 1);
-        Assert.Equal(data[1], 100);
+        Assert.Equal(1, data[0]);
+        Assert.Equal(100, data[1]);
     }
 
     [Fact]

--- a/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Strings.cs
+++ b/crates/backend_csharp/tests/reference_project/Tests/Test.Pattern.Strings.cs
@@ -16,7 +16,7 @@ public class TestPatternStrings
     public void pattern_ascii_pointer_2()
     {
         var rval = Interop.pattern_ascii_pointer_2();
-        Assert.Equal(rval, "hello.world");
+        Assert.Equal("hello.world", rval);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class TestPatternStrings
     public void pattern_string_12()
     {
         var rval = Interop.pattern_string_12(s1 => s1 + "world", "hello");
-        Assert.Equal(rval, "helloworld");
+        Assert.Equal("helloworld", rval);
     }
 
     [Fact]

--- a/crates/backend_csharp/tests/reference_project/Tests/Tests.csproj
+++ b/crates/backend_csharp/tests/reference_project/Tests/Tests.csproj
@@ -8,9 +8,9 @@
         <ProjectReference Include="..\Bindings\Bindings.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
-        <PackageReference Include="xunit" Version="2.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
+        <PackageReference Include="xunit.v3" Version="3.2.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
     </ItemGroup>
 </Project>

--- a/crates/backend_csharp/tests/reference_project/Tests/Tests.csproj
+++ b/crates/backend_csharp/tests/reference_project/Tests/Tests.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
+        <OutputType>Exe</OutputType>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
+        <!-- Conditional aot flag so dynamic code execution is allowed for debug builds but disabled when publishing the .exe -->
+        <PublishAot Condition="'$(Configuration)' == 'Release'">true</PublishAot>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Bindings\Bindings.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0"/>
-        <PackageReference Include="xunit.v3" Version="3.2.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
+        <PackageReference Include="xunit.v3.aot" Version="4.0.0-pre.128"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
     </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9384d5f057ed52752aa3dc5407e75b2265495154fb3a6597afe70b79f8776f93
+size 63


### PR DESCRIPTION
This is the first step to introduce the fixes necessary for #293.

The final goal is to add `DisableRuntimeMarshalling` to all the test projects. However, when I did that, additional issues arose from, e.g., function pointers that depended on runtime marshaling as well, not just the `Vec<T>` use case in #293.

Therefore, I decided to split the work into multiple smaller PRs and start with a common foundation: The AOT-compatible test project.

I migrated to xunit.v3.aot (still in prerelease) and fixed some warnings. The AOT package requires the new MicrosoftTestingPlatform, which is why some of the dotnet test commands were adjusted.

Note: I did not want to change the CI, so the tests still run normally in the CI. I only published and ran them locally.