### PR TITLE
fix: prevent async task handle use-after-free

### DIFF
--- a/crates/backend_csharp/templates/rust/fns/overload/body.cs
+++ b/crates/backend_csharp/templates/rust/fns/overload/body.cs
@@ -9,9 +9,13 @@
     {
         {% if is_async %}var (_cb, _cs) = Interop.{{ trampoline_field }}.NewCall();
         var _th = {{ name }}({% for arg in native_args %}{{arg.name}}, {% endfor %}_cb);
-        using var _cr = _ct.Register(() => { unsafe { _th.Abort(); } });
+        var _cr = _ct.Register(() => { unsafe { _th.Abort(); } });
         try { {% if is_task_void %}await _cs;{% else %}return await _cs;{% endif %} }
-        finally { unsafe { _th.Dispose(); } }{% else %}{% if not is_void %}return {% endif %}{{name}}({% for arg in native_args %}{{arg.name}}{% if not loop.last %}, {% endif %}{% endfor %});{% endif %}
+        finally
+        {
+            _cr.Dispose();
+            unsafe { _th.Dispose(); }
+        }{% else %}{% if not is_void %}return {% endif %}{{name}}({% for arg in native_args %}{{arg.name}}{% if not loop.last %}, {% endif %}{% endfor %});{% endif %}
 
     }
     finally
@@ -20,8 +24,12 @@
 {% endif %}{% endfor %}    }
 {% else %}{% if is_async %}    var (_cb, _cs) = Interop.{{ trampoline_field }}.NewCall();
     var _th = {{ name }}({% for arg in native_args %}{{arg.name}}, {% endfor %}_cb);
-    using var _cr = _ct.Register(() => { unsafe { _th.Abort(); } });
+    var _cr = _ct.Register(() => { unsafe { _th.Abort(); } });
     try { {% if is_task_void %}await _cs;{% else %}return await _cs;{% endif %} }
-    finally { unsafe { _th.Dispose(); } }
+    finally
+    {
+        _cr.Dispose();
+        unsafe { _th.Dispose(); }
+    }
 {% else %}    {% if not is_void %}return {% endif %}{{name}}({% for arg in native_args %}{{arg.name}}{% if not loop.last %}, {% endif %}{% endfor %});
 {% endif %}{% endif %}}

--- a/crates/backend_csharp/tests/reference_project/snapshots/r#mod__reference_project__interop.snap
+++ b/crates/backend_csharp/tests/reference_project/snapshots/r#mod__reference_project__interop.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dab01a04e50d8a34ef6ff79053de3ab8694d53d5f0075947131e6e8be8e4a194
-size 836023
+oid sha256:265be198a8fb00f935267c8653c35028938ef82ea4580c52f94630ac95febfe1
+size 836905


### PR DESCRIPTION
## Summary
- dispose cancellation registrations before freeing native task handles
- prevent cancellation callbacks from calling Abort through a freed Rust TaskHandleInner
- update the generated C# bindings snapshot

## Root cause
The generated async wrapper disposed TaskHandle before the using-declared CancellationTokenRegistration. A concurrent cancellation callback could therefore enter TaskHandle.Abort while TaskHandle.Dispose freed the backing Rust Box, causing use-after-free and process-level heap corruption.

## Validation
- reproduced as a Windows 0xC0000005 crash in TaskHandle.Abort
- fixed ordering survived 400,000 forced cancellation/completion races
- full C# reference suite passed (185 tests)
- reference-project binding snapshot generation passed