### PR TITLE
Fix service ownership mismatch in async constructors

### DIFF
--- a/crates/core/tests/ui/proc/svc/ctor_rval_bad_self.stderr
+++ b/crates/core/tests/ui/proc/svc/ctor_rval_bad_self.stderr
@@ -10,18 +10,11 @@ error[E0308]: mismatched types
 13 |     pub fn create() -> ffi::Result<u8, Error> {
    |            ^^^^^^
    |            |
-   |            expected `*const Service`, found `*mut u8`
-   |            arguments to this enum variant are incorrect
+   |            expected `Service`, found `u8`
+   |            arguments to this function are incorrect
    |
-   = note: expected raw pointer `*const Service`
-              found raw pointer `*mut u8`
-help: the type constructed contains `*mut u8` due to the type of the argument passed
-  --> tests/ui/proc/svc/ctor_rval_bad_self.rs:13:12
+note: associated function defined here
+  --> $RUST/alloc/src/sync.rs
    |
-13 |     pub fn create() -> ffi::Result<u8, Error> {
-   |            ^^^^^^ this argument influences the type of `Ok`
-note: tuple variant defined here
-  --> src/pattern/result.rs
-   |
-   |     Ok(T),
-   |     ^^
+   |     pub fn new(data: T) -> Arc<T> {
+   |            ^^^

--- a/crates/core/tests/ui/proc/svc/ctor_rval_bad_self.stderr
+++ b/crates/core/tests/ui/proc/svc/ctor_rval_bad_self.stderr
@@ -3,18 +3,3 @@ error[E0080]: evaluation panicked: This method looks like a constructor, but doe
    |
 13 |     pub fn create() -> ffi::Result<u8, Error> {
    |            ^^^^^^ evaluation of `_` failed here
-
-error[E0308]: mismatched types
-  --> tests/ui/proc/svc/ctor_rval_bad_self.rs:13:12
-   |
-13 |     pub fn create() -> ffi::Result<u8, Error> {
-   |            ^^^^^^
-   |            |
-   |            expected `Service`, found `u8`
-   |            arguments to this function are incorrect
-   |
-note: associated function defined here
-  --> $RUST/alloc/src/sync.rs
-   |
-   |     pub fn new(data: T) -> Arc<T> {
-   |            ^^^

--- a/crates/proc_macros_impl/src/service/emit.rs
+++ b/crates/proc_macros_impl/src/service/emit.rs
@@ -227,15 +227,10 @@ impl ServiceModel {
             quote_spanned! { ctor.name.span() => <#service_type>::#ctor_name }
         };
 
-        // Use Box for non-async services, Arc for async services
-        let into_raw_call = if self.is_async {
-            quote_spanned! { ctor.name.span() =>
-                ::std::sync::Arc::into_raw(::std::sync::Arc::new(service_instance))
-            }
-        } else {
-            quote_spanned! { ctor.name.span() =>
-                ::std::boxed::Box::into_raw(::std::boxed::Box::new(service_instance))
-            }
+        // Every service uses Arc because a service without its own async methods
+        // can still provide the runtime for another service's async constructor.
+        let into_raw_call = quote_spanned! { ctor.name.span() =>
+            ::std::sync::Arc::into_raw(::std::sync::Arc::new(service_instance))
         };
 
         let ffi_attr = self.emit_ffi_attr(&function_name);
@@ -460,13 +455,6 @@ impl ServiceModel {
         let service_type = &self.service_type;
         let generics = &self.generics;
 
-        // Use Box for non-async services, Arc for async services
-        let from_raw_call = if self.is_async {
-            quote_spanned! { self.service_name.span() => let _ = ::std::sync::Arc::from_raw(instance); }
-        } else {
-            quote_spanned! { self.service_name.span() => let _ = ::std::boxed::Box::from_raw(instance as *mut #service_type); }
-        };
-
         let ffi_attr = self.emit_ffi_attr(&function_name);
 
         quote_spanned! { self.service_name.span() =>
@@ -475,7 +463,7 @@ impl ServiceModel {
             fn #function_name #generics(instance: *const #service_type) {
                 if !instance.is_null() {
                     unsafe {
-                        #from_raw_call
+                        let _ = ::std::sync::Arc::from_raw(instance);
                     }
                 }
             }

--- a/crates/proc_macros_impl/src/service/emit.rs
+++ b/crates/proc_macros_impl/src/service/emit.rs
@@ -230,7 +230,7 @@ impl ServiceModel {
         // Every service uses Arc because a service without its own async methods
         // can still provide the runtime for another service's async constructor.
         let into_raw_call = quote_spanned! { ctor.name.span() =>
-            ::std::sync::Arc::into_raw(::std::sync::Arc::new(service_instance))
+            ::std::sync::Arc::into_raw(::std::sync::Arc::new(service_instance)) as *mut _
         };
 
         let ffi_attr = self.emit_ffi_attr(&function_name);

--- a/crates/proc_macros_impl/src/service/mod.rs
+++ b/crates/proc_macros_impl/src/service/mod.rs
@@ -1,6 +1,8 @@
 mod args;
 mod emit;
 mod model;
+#[cfg(test)]
+mod tests;
 mod validation;
 
 use proc_macro2::TokenStream;

--- a/crates/proc_macros_impl/src/service/tests.rs
+++ b/crates/proc_macros_impl/src/service/tests.rs
@@ -1,0 +1,21 @@
+use crate::service::args::FfiServiceArgs;
+use crate::service::model::ServiceModel;
+use syn::parse_quote;
+
+#[test]
+fn sync_service_uses_arc_storage() {
+    let input = parse_quote! {
+        impl RuntimeService {
+            pub fn new() -> Self {
+                Self
+            }
+        }
+    };
+    let model = ServiceModel::from_impl_item(input, FfiServiceArgs::default()).unwrap();
+    let emitted = model.emit_ffi_functions().to_string();
+
+    assert!(emitted.contains("Arc :: into_raw"));
+    assert!(emitted.contains("Arc :: from_raw"));
+    assert!(!emitted.contains("Box :: into_raw"));
+    assert!(!emitted.contains("Box :: from_raw"));
+}

--- a/crates/proc_macros_impl/tests/snapshots/svc_async__async_service.snap
+++ b/crates/proc_macros_impl/tests/snapshots/svc_async__async_service.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bdcbc83f46e60bcf8852863b1325e612375e4db4ebcbdb77444468cfb33b541e
-size 6243
+oid sha256:0cc9f3eb48548aab11fadd7d31afe703d4af212ee0b217d0d2902fdc11727c51
+size 6273

--- a/crates/proc_macros_impl/tests/snapshots/svc_export__export_unique.snap
+++ b/crates/proc_macros_impl/tests/snapshots/svc_export__export_unique.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd878eeb88118ffb4ee17c84d404e7ecbf27e1924665526c53d5df95f2db04f0
-size 3071
+oid sha256:c55be7759befc1e21cc5f5421335d984f0d2e531505e1797d8c4d9e473a88914
+size 3052

--- a/crates/proc_macros_impl/tests/snapshots/svc_export__export_unique.snap
+++ b/crates/proc_macros_impl/tests/snapshots/svc_export__export_unique.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c55be7759befc1e21cc5f5421335d984f0d2e531505e1797d8c4d9e473a88914
-size 3052
+oid sha256:5dd3ae340fbd4f8cd34358fb86f7ac3b2752104c556a1256f8dd0d1f50dec3b4
+size 3082

--- a/crates/proc_macros_impl/tests/snapshots/svc_lifetime__supports_lifetimes.snap
+++ b/crates/proc_macros_impl/tests/snapshots/svc_lifetime__supports_lifetimes.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81390315876745e9b3a50e437c78152e610d1cc6754a3d016e531dfdafc0bf51
-size 3863
+oid sha256:62710c37111da8e85b4c79adba15b76a25071f84f12e5f9a6fd66bb5f197c7ca
+size 3844

--- a/crates/proc_macros_impl/tests/snapshots/svc_lifetime__supports_lifetimes.snap
+++ b/crates/proc_macros_impl/tests/snapshots/svc_lifetime__supports_lifetimes.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62710c37111da8e85b4c79adba15b76a25071f84f12e5f9a6fd66bb5f197c7ca
-size 3844
+oid sha256:ea8637ebb6859af60e2079203cba0667ded30f46c650aba22c83edd9ef3c1ea9
+size 3874

--- a/crates/proc_macros_impl/tests/snapshots/svc_skip__skip_impl.snap
+++ b/crates/proc_macros_impl/tests/snapshots/svc_skip__skip_impl.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32df27d4551a429f53fc0bce1a038919939ea7819f79d87e80fdbc4260582136
-size 1523
+oid sha256:93727f8818b9ae33ec1b7accc474d660397a6beb2e8572a8c33c9709794bc345
+size 1506


### PR DESCRIPTION
## Root cause

Generated service constructors used `Box` for services without their own async methods, while async-constructor trampolines always reconstructed their runtime service pointer as `Arc`.

`ServiceAsyncBasic` only provides a Tokio runtime, so `ServiceAsyncBasic.Simple()` returned a `Box` pointer and `ServiceAsyncCtor.NewAsync()` performed `Arc::from_raw` on it. On Linux this accessed the allocator metadata 16 bytes before the allocation and intermittently corrupted glibc's heap during parallel tests.

## Fix

- Store every generated service handle in `Arc`, regardless of whether that service declares async methods itself.
- Destroy every generated service handle with the matching `Arc::from_raw`.
- Add a proc-macro regression test and update affected expansion snapshots.

## Validation

- Valgrind no longer reports the invalid `Arc` reads in `service_async_ctor_new_async`.
- Linux full .NET suite passed 100 consecutive runs.
- Windows .NET reference suite passed all 185 tests.
- Proc-macro tests and clippy pass.
